### PR TITLE
fpga: litex: Update for "Use standard dev_release for class driver"

### DIFF
--- a/Documentation/devicetree/bindings/clock/litex,clock.yaml
+++ b/Documentation/devicetree/bindings/clock/litex,clock.yaml
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: GPL-2.0
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/clock/litex,clock.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: LiteX clock control driver
+
+description: |
+  Common clock driver with MMCM unit for dynamic reconfiguration
+  of up to 7 clock outputs with ability to change frequency, duty
+  cycle and phase offset
+
+maintainers:
+  - Karol Gugala <kgugala@antmicro.com>
+  - Mateusz Holenko <mholenko@antmicro.com>
+
+properties:
+  compatible:
+    const: litex,clock
+
+  reg:
+    description: Base address and lengths of the register space
+
+  "#clock-cells":
+    description:
+      Number of cells in a clock specifier;
+      Typically 0 for nodes with a single clock output
+      and 1 for nodes with multiple clock outputs.
+    const: 1
+
+  "#address-cells":
+    description:
+      Number of cells that are needed to form the base address
+      part in the reg property.
+    const: 1
+
+  "#size-cells":
+    description:
+      Used to state how many cells are in each field of a reg property
+    const: 0
+
+  clock-output-names:
+    description:
+      List of strings of clock output signal names indexed
+      by the first cell in the clock specifier.
+    minItems: 1
+    maxItems: 7
+    items:
+      - const: CLKOUT0
+      - const: CLKOUT1
+      - const: CLKOUT2
+      - const: CLKOUT3
+      - const: CLKOUT4
+      - const: CLKOUT5
+      - const: CLKOUT6
+
+  litex,nclkout:
+    description: Number of desired clock outputs
+    $ref: /schemas/types.yaml#/definitions/uint32
+    minimum: 1
+    maximum: 7
+
+  litex,lock-timeout:
+    description: Number of ms to wait for MMCM to assert LOCK signal
+    $ref: /schemas/types.yaml#/definitions/uint32
+    minimum: 1
+
+  litex,drdy-timeout:
+    description: Number of ms to wait for MMCM to assert DRDY signal
+    $ref: /schemas/types.yaml#/definitions/uint32
+    minimum: 1
+
+  litex,sys-clock-freq:
+    description: System clock frequency
+    $ref: /schemas/types.yaml#/definitions/uint32
+
+patternProperties:
+  "^CLKOUT[0-6]$":
+    description:
+      Child node representing configurable clock outputs of MMCM unit
+    type: object
+
+    properties:
+      compatible:
+        const: litex,clock
+
+      reg:
+        description: clock output ID, zero-based numbering
+
+      litex,clock-frequency:
+        description: default frequency in Hz for clock output
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1587000
+        maximum: 100000000
+
+      litex,clock-phase:
+        description: default phase offset given in degrees
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 0
+        maximum: 359
+
+      litex,clock-duty-num:
+        description: default duty cycle numerator value
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 100
+
+      litex,clock-duty-den:
+        description: default duty cycle denominator value
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 100
+
+    required:
+      - compatible
+      - "#clock-cells"
+      - clock-output-names
+      - reg
+      - litex,clock-frequency
+      - litex,clock-phase
+      - litex,clock-duty-num
+      - litex,clock-duty-den
+
+required:
+  - compatible
+  - reg
+  - "#clock-cells"
+  - "#address-cells"
+  - "#size-cells"
+  - clock-output-names
+  - litex,nclkout
+  - CLKOUTx
+
+additionalProperties: false
+
+examples:
+  - |
+    clk0: clock-controller@f0003000 {
+            compatible = "litex,clk";
+            reg = <0x0 0xf0003000>, <0x0 0x100>;
+            #clock-cells =        <1>;
+            #address-cells = <1>;
+            #size-cells = <0>;
+            clock-output-names = "CLKOUT0",
+                                 "CLKOUT1",
+                                 "CLKOUT2",
+                                 "CLKOUT3",
+                                 "CLKOUT4",
+                                 "CLKOUT5",
+                                 "CLKOUT6";
+            litex,nclkout = <7>;
+
+            CLKOUT0: CLKOUT0@0 {
+                    compatible = "litex,clk";
+                    #clock-cells = <0>;
+                    clock-output-names = "CLKOUT0";
+                    reg = <0>;
+                    litex,clock-frequency = <50000000>;
+                    litex,clock-phase = <0>;
+                    litex,clock-duty = <50>;
+            };
+
+            CLKOUT1: CLKOUT1@1 {
+                    compatible = "litex,clk";
+                    #clock-cells = <0>;
+                    clock-output-names = "CLKOUT1";
+                    reg = <1>;
+                    litex,clock-frequency = <50000000>;
+                    litex,clock-phase = <90>;
+                    litex,clock-duty = <50>;
+            };
+
+            CLKOUT2: CLKOUT2@2 {
+                    compatible = "litex,clk";
+                    #clock-cells = <0>;
+                    clock-output-names = "CLKOUT2";
+                    reg = <2>;
+                    litex,clock-frequency = <25000000>;
+                    litex,clock-phase = <0>;
+                    litex,clock-duty = <25>;
+            };
+
+            CLKOUT3: CLKOUT3@3 {
+                    compatible = "litex,clk";
+                    #clock-cells = <0>;
+                    clock-output-names = "CLKOUT3";
+                    reg = <3>;
+                    litex,clock-frequency = <12500000>;
+                    litex,clock-phase = <0>;
+                    litex,clock-duty = <75>;
+            };
+
+            CLKOUT4: CLKOUT4@4 {
+                    compatible = "litex,clk";
+                    #clock-cells = <0>;
+                    clock-output-names = "CLKOUT4";
+                    reg = <4>;
+                    litex,clock-frequency = <6250000>;
+                    litex,clock-phase = <0>;
+                    litex,clock-duty = <50>;
+            };
+
+            CLKOUT5: CLKOUT5@5 {
+                    compatible = "litex,clk";
+                    #clock-cells = <0>;
+                    clock-output-names = "CLKOUT5";
+                    reg = <5>;
+                    litex,clock-frequency = <3125000>;
+                    litex,clock-phase = <0>;
+                    litex,clock-duty = <50>;
+            };
+
+            CLKOUT6: CLKOUT6@6 {
+                    compatible = "litex,clk";
+                    #clock-cells = <0>;
+                    clock-output-names = "CLKOUT6";
+                    reg = <6>;
+                    litex,clock-frequency = <1562500>;
+                    litex,clock-phase = <0>;
+                    litex,clock-duty = <5>;
+            };
+    };
+...

--- a/Documentation/devicetree/bindings/gpu/litex,litevideo.txt
+++ b/Documentation/devicetree/bindings/gpu/litex,litevideo.txt
@@ -1,0 +1,34 @@
+DRM LiteX LiteVideo driver
+
+Required properties:
+- compatible: should be "litex,litevideo"
+- reg: base address of configuration registers with length
+- litevideo,pixel-clock: pixel clock frequency in kHz
+- litevideo,h-active: horizontal active pixels
+- litevideo,h-blanking: total horizontal blanking
+- litevideo,h-sync: horizontal sync width
+- litevideo,h-front-porch: horizontal front porch
+- litevideo,v-active: vertical active pixels
+- litevideo,v-blanking: vertical total blanking
+- litevideo,v-sync: vertical sync width
+- litevideo,v-front-porch: vertical front porch
+- litevideo,dma-offset: dma offset in memory
+- litevideo,dma-length: size of memory used for storing the image
+
+Examples:
+
+litevideo0: gpu@f0009800 {
+	compatible = "litex,litevideo";
+	reg = <0x0 0xf0009800 0x0 0x100>;
+	litevideo,pixel-clock = <148500>;
+	litevideo,h-active = <1920>;
+	litevideo,h-blanking = <280>;
+	litevideo,h-sync = <44>;
+	litevideo,h-front-porch = <148>;
+	litevideo,v-active = <1080>;
+	litevideo,v-blanking = <45>;
+	litevideo,v-sync = <5>;
+	litevideo,v-front-porch = <36>;
+	litevideo,dma-offset = <0x8000000>;
+	litevideo,dma-length = <0x7e9000>;
+};

--- a/drivers/clk/Kconfig
+++ b/drivers/clk/Kconfig
@@ -395,6 +395,12 @@ config COMMON_CLK_K210
 	help
 	  Support for the Canaan Kendryte K210 RISC-V SoC clocks.
 
+config COMMON_CLK_LITEX
+	tristate "LiteX Clock control support"
+	depends on COMMON_CLK && OF && LITEX_SOC_CONTROLLER
+	help
+	  Clock control support for LiteX SoC builder, utilising MMCM unit and DRP registers
+
 source "drivers/clk/actions/Kconfig"
 source "drivers/clk/analogbits/Kconfig"
 source "drivers/clk/baikal-t1/Kconfig"

--- a/drivers/clk/Makefile
+++ b/drivers/clk/Makefile
@@ -38,6 +38,7 @@ obj-$(CONFIG_CLK_HSDK)			+= clk-hsdk-pll.o
 obj-$(CONFIG_COMMON_CLK_K210)		+= clk-k210.o
 obj-$(CONFIG_LMK04832)			+= clk-lmk04832.o
 obj-$(CONFIG_COMMON_CLK_LAN966X)	+= clk-lan966x.o
+obj-$(CONFIG_COMMON_CLK_LITEX)		+= clk-litex.o
 obj-$(CONFIG_COMMON_CLK_LOCHNAGAR)	+= clk-lochnagar.o
 obj-$(CONFIG_COMMON_CLK_MAX77686)	+= clk-max77686.o
 obj-$(CONFIG_COMMON_CLK_MAX9485)	+= clk-max9485.o

--- a/drivers/clk/clk-litex.c
+++ b/drivers/clk/clk-litex.c
@@ -1,0 +1,1786 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright (c) 2020 Antmicro Ltd. <www.antmicro.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ */
+#include "clk-litex.h"
+#include <linux/litex.h>
+#include <linux/platform_device.h>
+#include <linux/module.h>
+#include <linux/clk-provider.h>
+#include <linux/delay.h>
+
+struct litex_drp_reg {
+	u32 offset;
+	u32 size;
+};
+
+struct litex_drp_reg drp[] = {
+	{DRP_OF_RESET,  DRP_SIZE_RESET},
+	{DRP_OF_READ,   DRP_SIZE_READ},
+	{DRP_OF_WRITE,  DRP_SIZE_WRITE},
+	{DRP_OF_DRDY,   DRP_SIZE_DRDY},
+	{DRP_OF_ADR,    DRP_SIZE_ADR},
+	{DRP_OF_DAT_W,  DRP_SIZE_DAT_W},
+	{DRP_OF_DAT_R,  DRP_SIZE_DAT_R},
+	{DRP_OF_LOCKED, DRP_SIZE_LOCKED},
+};
+
+struct litex_clk_device {
+	void __iomem *base;
+	int is_clkout;
+	struct clk_hw clk_hw;
+	struct litex_clk_clkout *clkouts;
+	u32 nclkout;
+	u32 lock_timeout;
+	u32 drdy_timeout;
+	u32 sys_clk_freq;
+};
+
+struct litex_clk_clkout_addr {
+	u8 reg1;
+	u8 reg2;
+};
+
+struct litex_clk_regs_addr {
+	struct litex_clk_clkout_addr clkout[CLKOUT_MAX];
+};
+
+struct litex_clk_clkout {
+	void __iomem *base;
+	int is_clkout;
+	struct clk_hw clk_hw;
+	u32 id;
+	u32 default_freq;
+	u32 default_phase;
+	u32 default_duty_num;
+	u32 default_duty_den;
+	u32 lock_timeout;
+	u32 drdy_timeout;
+	u32 sys_clk_freq;
+};
+
+struct litex_clk_regs_addr litex_clk_regs_addr_init(void)
+{
+	struct litex_clk_regs_addr m;
+	u32 i, addr;
+
+	addr = CLKOUT0_REG1;
+	for (i = 0; i <= CLKOUT_MAX; i++) {
+		if (i == 5) {
+		/*
+		 *special case because CLKOUT5 have its reg addresses
+		 *placed lower than other CLKOUTs
+		 */
+			m.clkout[5].reg1 = CLKOUT5_REG1;
+			m.clkout[5].reg2 = CLKOUT5_REG2;
+		} else {
+			m.clkout[i].reg1 = addr;
+			addr++;
+			m.clkout[i].reg2 = addr;
+			addr++;
+		}
+	}
+	return m;
+}
+
+/*
+ * This code is taken from:
+ * https://github.com/torvalds/linux/blob/master/drivers/clk/clk-axi-clkgen.c
+ *
+ *	Copyright 2012-2013 Analog Devices Inc.
+ *	Author: Lars-Peter Clausen <lars@metafoo.de>
+ *
+ * FIXME: make this code common
+ */
+
+/* MMCM loop filter lookup table */
+static u32 litex_clk_lookup_filter(u32 glob_mul)
+{
+	switch (glob_mul) {
+	case 0:
+		return 0x01001990;
+	case 1:
+		return 0x01001190;
+	case 2:
+		return 0x01009890;
+	case 3:
+		return 0x01001890;
+	case 4:
+		return 0x01008890;
+	case 5 ... 8:
+		return 0x01009090;
+	case 9 ... 11:
+		return 0x01000890;
+	case 12:
+		return 0x08009090;
+	case 13 ... 22:
+		return 0x01001090;
+	case 23 ... 36:
+		return 0x01008090;
+	case 37 ... 46:
+		return 0x08001090;
+	default:
+		return 0x08008090;
+	}
+}
+
+/* MMCM lock detection lookup table */
+static const u32 litex_clk_lock_table[] = {
+	0x060603e8, 0x060603e8, 0x080803e8, 0x0b0b03e8,
+	0x0e0e03e8, 0x111103e8, 0x131303e8, 0x161603e8,
+	0x191903e8, 0x1c1c03e8, 0x1f1f0384, 0x1f1f0339,
+	0x1f1f02ee, 0x1f1f02bc, 0x1f1f028a, 0x1f1f0271,
+	0x1f1f023f, 0x1f1f0226, 0x1f1f020d, 0x1f1f01f4,
+	0x1f1f01db, 0x1f1f01c2, 0x1f1f01a9, 0x1f1f0190,
+	0x1f1f0190, 0x1f1f0177, 0x1f1f015e, 0x1f1f015e,
+	0x1f1f0145, 0x1f1f0145, 0x1f1f012c, 0x1f1f012c,
+	0x1f1f012c, 0x1f1f0113, 0x1f1f0113, 0x1f1f0113,
+};
+
+/* Helper function for lock lookup table */
+static u32 litex_clk_lookup_lock(u32 glob_mul)
+{
+	if (glob_mul < ARRAY_SIZE(litex_clk_lock_table))
+		return litex_clk_lock_table[glob_mul];
+	return 0x1f1f00fa;
+}
+/* End of copied code */
+
+static inline struct litex_clk_device *clk_hw_to_litex_clk_device
+						  (struct clk_hw *clk_hw)
+{
+	return container_of(clk_hw, struct litex_clk_device, clk_hw);
+}
+
+static inline struct litex_clk_clkout *clk_hw_to_litex_clk_clkout
+						  (struct clk_hw *clk_hw)
+{
+	return container_of(clk_hw, struct litex_clk_clkout, clk_hw);
+}
+
+/* Clock control driver functions */
+static inline void litex_clk_set_reg(struct clk_hw *clk_hw, u32 reg, u32 val)
+{
+	struct litex_clk_clkout *l_clk = clk_hw_to_litex_clk_clkout(clk_hw);
+
+	_litex_set_reg(l_clk->base + drp[reg].offset, drp[reg].size, val);
+}
+
+static inline u32 litex_clk_get_reg(struct clk_hw *clk_hw, u32 reg)
+{
+	struct litex_clk_clkout *l_clk = clk_hw_to_litex_clk_clkout(clk_hw);
+
+	return _litex_get_reg(l_clk->base + drp[reg].offset, drp[reg].size);
+}
+
+static inline void litex_clk_assert_reg(struct clk_hw *clk_hw, u32 reg)
+{
+	int assert = (1 << (drp[reg].size * BITS_PER_BYTE)) - 1;
+
+	litex_clk_set_reg(clk_hw, reg, assert);
+}
+
+static inline void litex_clk_deassert_reg(struct clk_hw *clk_hw, u32 reg)
+{
+	litex_clk_set_reg(clk_hw, reg, ZERO_REG);
+}
+
+static int litex_clk_wait_lock(struct clk_hw *clk_hw)
+{
+	struct litex_clk_clkout *l_clk;
+	u32 timeout;
+
+	l_clk = clk_hw_to_litex_clk_clkout(clk_hw);
+
+	/* Check if clk_hw is global or clkout specific */
+	if (l_clk->is_clkout) {
+		timeout = l_clk->lock_timeout;
+	} else {
+		/* clk hw is global */
+		struct litex_clk_device *l_dev;
+
+		l_dev = clk_hw_to_litex_clk_device(clk_hw);
+		timeout = l_dev->lock_timeout;
+	}
+
+	/*Waiting for LOCK signal to assert in MMCM*/
+	while (!litex_clk_get_reg(clk_hw, DRP_LOCKED) && timeout) {
+		timeout--;
+		usleep_range(900, 1000);
+	}
+	if (timeout == 0) {
+		pr_err("CLKOUT%d: %s timeout", l_clk->id, __func__);
+		return -ETIME;
+	}
+	return 0;
+}
+
+static int litex_clk_wait_drdy(struct clk_hw *clk_hw)
+{
+	struct litex_clk_clkout *l_clk;
+	u32 timeout;
+
+	l_clk = clk_hw_to_litex_clk_clkout(clk_hw);
+
+	/* Check if clk_hw is global or clkout specific */
+	if (l_clk->is_clkout) {
+		timeout = l_clk->drdy_timeout;
+	} else {
+		/* clk hw is global */
+		struct litex_clk_device *l_dev;
+
+		l_dev = clk_hw_to_litex_clk_device(clk_hw);
+		timeout = l_dev->drdy_timeout;
+	}
+
+	/*Waiting for DRDY signal to assert in MMCM*/
+	while (!litex_clk_get_reg(clk_hw, DRP_DRDY) && timeout) {
+		timeout--;
+		usleep_range(900, 1000);
+	}
+	if (timeout == 0) {
+		pr_err("CLKOUT%d: %s timeout", l_clk->id, __func__);
+		return -ETIME;
+	}
+	return 0;
+}
+
+/* Read value written in given internal MMCM register*/
+static int litex_clk_get_DO(struct clk_hw *clk_hw, u8 clk_reg_addr, u16 *res)
+{
+	int ret;
+
+	litex_clk_set_reg(clk_hw, DRP_ADR, clk_reg_addr);
+	litex_clk_assert_reg(clk_hw, DRP_READ);
+
+	litex_clk_deassert_reg(clk_hw, DRP_READ);
+	ret = litex_clk_wait_drdy(clk_hw);
+	if (ret != 0)
+		return ret;
+
+	*res = litex_clk_get_reg(clk_hw, DRP_DAT_R);
+
+	return 0;
+}
+
+/* Return global divider and multiplier values */
+static int litex_clk_get_global_divider(struct clk_hw *hw, u32 *divider,
+							   u32 *multiplier)
+{
+	int ret;
+	u16 divreg, mult;
+	u8 low_time, high_time;
+
+	ret = litex_clk_get_DO(hw, CLKFBOUT_REG1, &mult);
+	if (ret != 0)
+		return ret;
+	ret = litex_clk_get_DO(hw, DIV_REG, &divreg);
+	if (ret != 0)
+		return ret;
+
+	low_time = mult & HL_TIME_MASK;
+	high_time = (mult >> HIGH_TIME_POS) & HL_TIME_MASK;
+	*multiplier = low_time + high_time;
+
+	low_time = divreg & HL_TIME_MASK;
+	high_time = (divreg >> HIGH_TIME_POS) & HL_TIME_MASK;
+	*divider = low_time + high_time;
+
+	return 0;
+}
+
+/* Calculate frequency after global divider and multiplier */
+static u32 litex_clk_get_real_global_frequency(struct clk_hw *hw)
+{
+	struct litex_clk_clkout *l_clkout = clk_hw_to_litex_clk_clkout(hw);
+	u32 g_divider, g_multiplier;
+
+	litex_clk_get_global_divider(hw, &g_divider, &g_multiplier);
+	return l_clkout->sys_clk_freq * g_multiplier / g_divider;
+}
+
+/* Calculate frequency after global divider and multiplier without clk_hw */
+static u32 litex_clk_get_expctd_global_frequency(u32 sys_clk_freq)
+{
+	u32 g_divider, g_multiplier;
+
+	g_divider = (GLOB_DIV_VAL & HL_TIME_MASK) +
+		   ((GLOB_DIV_VAL >> HIGH_TIME_POS) & HL_TIME_MASK);
+
+	g_multiplier = (GLOB_MUL_VAL & HL_TIME_MASK) +
+		      ((GLOB_MUL_VAL >> HIGH_TIME_POS) & HL_TIME_MASK);
+
+	return sys_clk_freq * g_multiplier / g_divider;
+}
+/* Return dividers of given CLKOUT */
+static int litex_clk_get_clkout_divider(struct clk_hw *hw, u32 *divider,
+							   u32 *fract_cnt)
+{
+	struct litex_clk_clkout *l_clkout = clk_hw_to_litex_clk_clkout(hw);
+	struct litex_clk_regs_addr drp_addr = litex_clk_regs_addr_init();
+	int ret;
+	u16 div, frac;
+	u8 clkout_nr = l_clkout->id;
+	u8 low_time, high_time;
+
+	ret = litex_clk_get_DO(hw, drp_addr.clkout[clkout_nr].reg1, &div);
+	if (ret != 0)
+		return ret;
+	ret = litex_clk_get_DO(hw, drp_addr.clkout[clkout_nr].reg2, &frac);
+	if (ret != 0)
+		return ret;
+
+	low_time = div & HL_TIME_MASK;
+	high_time = (div >> HIGH_TIME_POS) & HL_TIME_MASK;
+	*divider = low_time + high_time;
+	*fract_cnt = (frac >> FRAC_POS) & FRAC_MASK;
+
+	return 0;
+}
+
+/* Debug functions */
+#ifdef DEBUG
+static void litex_clk_print_general_regs(struct clk_hw *clk_hw)
+{
+	u16 power_reg, div_reg, clkfbout_reg, lock_reg1,
+	lock_reg2, lock_reg3, filt_reg1, filt_reg2;
+
+	litex_clk_get_DO(clk_hw, POWER_REG, &power_reg);
+	litex_clk_get_DO(clk_hw, DIV_REG, &div_reg);
+	litex_clk_get_DO(clk_hw, CLKFBOUT_REG1, &clkfbout_reg);
+	litex_clk_get_DO(clk_hw, LOCK_REG1, &lock_reg1);
+	litex_clk_get_DO(clk_hw, LOCK_REG2, &lock_reg2);
+	litex_clk_get_DO(clk_hw, LOCK_REG3, &lock_reg3);
+	litex_clk_get_DO(clk_hw, FILT_REG1, &filt_reg1);
+	litex_clk_get_DO(clk_hw, FILT_REG2, &filt_reg2);
+
+	pr_debug("POWER REG:  0x%x\n", power_reg);
+	pr_debug("DIV REG:    0x%x\n", div_reg);
+	pr_debug("MUL REG:    0x%x\n", clkfbout_reg);
+	pr_debug("LOCK_REG1:  0x%x\n", lock_reg1);
+	pr_debug("LOCK_REG2:  0x%x\n", lock_reg2);
+	pr_debug("LOCK_REG3:  0x%x\n", lock_reg3);
+	pr_debug("FILT_REG1:  0x%x\n", filt_reg1);
+	pr_debug("FILT_REG2:  0x%x\n", filt_reg2);
+}
+
+static void litex_clk_print_clkout_regs(struct clk_hw *clk_hw, u8 clkout,
+						      u8 reg1, u8 reg2)
+{
+	u16 clkout_reg1, clkout_reg2;
+
+	litex_clk_get_DO(clk_hw, reg1, &clkout_reg1);
+	pr_debug("CLKOUT%d REG1: 0x%x\n", clkout, clkout_reg1);
+
+	litex_clk_get_DO(clk_hw, reg1, &clkout_reg2);
+	pr_debug("CLKOUT%d REG2: 0x%x\n", clkout, clkout_reg2);
+}
+
+static void litex_clk_print_all_regs(struct clk_hw *clk_hw)
+{
+	struct litex_clk_regs_addr drp_addr = litex_clk_regs_addr_init();
+	u32 i;
+
+	pr_debug("General regs:\n");
+	litex_clk_print_general_regs(clk_hw);
+	for (i = 0; i < CLKOUT_MAX; i++)
+		litex_clk_print_clkout_regs(clk_hw, i, drp_addr.clkout[i].reg1,
+						       drp_addr.clkout[i].reg2);
+}
+#endif /* #ifdef DEBUG */
+
+/* Return raw value ready to be written into DRP */
+static inline u16 litex_clk_calc_DI(u16 DO_val, u16 mask, u16 bitset)
+{
+	u16 DI_val;
+
+	DI_val = DO_val & mask;
+	DI_val |= bitset;
+
+	return DI_val;
+}
+
+/* Sets calculated DI value into DI DRP register */
+static int litex_clk_set_DI(struct clk_hw *clk_hw, u16 DI_val)
+{
+	int ret;
+
+	litex_clk_set_reg(clk_hw, DRP_DAT_W, DI_val);
+	litex_clk_assert_reg(clk_hw, DRP_WRITE);
+	litex_clk_deassert_reg(clk_hw, DRP_WRITE);
+	ret = litex_clk_wait_drdy(clk_hw);
+	if (ret != 0)
+		return ret;
+	return 0;
+}
+
+/*
+ * Change register value as specified in arguments
+ *
+ * clk_hw:		hardware specific clock structure for selecting CLKOUT
+ * mask:		preserve or zero MMCM register bits
+ *			by selecting 1 or 0 on desired specific mask positions
+ * bitset:		set those bits in MMCM register which are 1 in bitset
+ * clk_reg_addr:	internal MMCM address of control register
+ *
+ */
+static int litex_clk_change_value(struct clk_hw *clk_hw, u16 mask, u16 bitset,
+							  u8 clk_reg_addr)
+{
+	u16 DO_val, DI_val;
+	int ret;
+
+	litex_clk_assert_reg(clk_hw, DRP_RESET);
+
+	ret = litex_clk_get_DO(clk_hw, clk_reg_addr, &DO_val);
+	if (ret != 0)
+		return ret;
+	DI_val = litex_clk_calc_DI(DO_val, mask, bitset);
+	ret = litex_clk_set_DI(clk_hw, DI_val);
+	if (ret != 0)
+		return ret;
+#ifdef DEBUG
+	DI_val = litex_clk_get_reg(clk_hw, DRP_DAT_W);
+#endif
+	litex_clk_deassert_reg(clk_hw, DRP_DAT_W);
+	litex_clk_deassert_reg(clk_hw, DRP_RESET);
+	ret = litex_clk_wait_lock(clk_hw);
+	if (ret != 0)
+		return ret;
+
+	pr_debug("set 0x%x under addr: 0x%x", DI_val, clk_reg_addr);
+	return 0;
+}
+
+/*
+ * Set register values for given CLKOUT
+ *
+ * clk_hw:		hardware specific clock structure for selecting CLKOUT
+ * clkout_nr:		clock output number
+ * mask_regX:		preserve or zero MMCM register X bits
+ *			by selecting 1 or 0 on desired specific mask positions
+ * bitset_regX:		set those bits in MMCM register X  which are 1 in bitset
+ *
+ */
+static int litex_clk_set_clock(struct clk_hw *clk_hw, u8 clkout_nr,
+					u16 mask_reg1, u16 bitset_reg1,
+					u16 mask_reg2, u16 bitset_reg2)
+{
+	struct litex_clk_regs_addr drp_addr = litex_clk_regs_addr_init();
+	int ret;
+
+	if (!(mask_reg2 == KEEP_REG_16 && bitset_reg2 == ZERO_REG)) {
+		ret = litex_clk_change_value(clk_hw, mask_reg2, bitset_reg2,
+					    drp_addr.clkout[clkout_nr].reg2);
+		if (ret != 0)
+			return ret;
+	}
+	if (!(mask_reg1 == KEEP_REG_16 && bitset_reg1 == ZERO_REG)) {
+		ret = litex_clk_change_value(clk_hw, mask_reg1, bitset_reg1,
+					drp_addr.clkout[clkout_nr].reg1);
+		if (ret != 0)
+			return ret;
+	}
+	return 0;
+}
+
+/*
+ * Set global divider for all CLKOUTs
+ *
+ * clk_hw:		hardware specific clock structure
+ * mask:		preserve or zero MMCM register bits
+ *			by selecting 1 or 0 on desired specific mask positions
+ * bitset:		set those bits in MMCM register which are 1 in bitset
+ *
+ */
+static int litex_clk_set_divreg(struct clk_hw *clk_hw, u16 mask, u16 bitset)
+{
+	int ret;
+
+	ret = litex_clk_change_value(clk_hw, mask, bitset, DIV_REG);
+	if (ret != 0)
+		return ret;
+	pr_debug("Global divider set to %d", (bitset % (1 << HIGH_TIME_POS)) +
+			  ((bitset >> HIGH_TIME_POS) % (1 << HIGH_TIME_POS)));
+	return 0;
+}
+
+/*
+ * Set global multiplier for all CLKOUTs
+ *
+ * clk_hw:		hardware specific clock structure
+ * mask:		preserve or zero MMCM register bits
+ *			by selecting 1 or 0 on desired specific mask positions
+ * bitset:		set those bits in MMCM register which are 1 in bitset
+ *
+ */
+static int litex_clk_set_mulreg(struct clk_hw *clk_hw, u16 mask, u16 bitset)
+{
+	int ret;
+
+	ret = litex_clk_change_value(clk_hw, mask, bitset, CLKFBOUT_REG1);
+	if (ret != 0)
+		return ret;
+	pr_debug("Global multiplier set to %d",
+		(bitset % (1 << HIGH_TIME_POS)) + ((bitset >> HIGH_TIME_POS) %
+							(1 << HIGH_TIME_POS)));
+	return 0;
+}
+
+static int litex_clk_set_filt(struct clk_hw *hw)
+{
+	u32 filt, mul;
+	int ret;
+
+	mul = GLOB_MUL_VAL && HL_TIME_MASK;
+	mul += (GLOB_MUL_VAL >> HIGH_TIME_POS) && HL_TIME_MASK;
+
+	filt = litex_clk_lookup_filter(mul - 1);
+
+	ret = litex_clk_change_value(hw, FILT_MASK, filt >> 16, FILT_REG1);
+	if (ret != 0)
+		return ret;
+	ret = litex_clk_change_value(hw, FILT_MASK, filt, FILT_REG2);
+	if (ret != 0)
+		return ret;
+	return 0;
+}
+
+static int litex_clk_set_lock(struct clk_hw *hw)
+{
+	u32 lock, mul;
+	int ret;
+
+	mul = GLOB_MUL_VAL && HL_TIME_MASK;
+	mul += (GLOB_MUL_VAL >> HIGH_TIME_POS) && HL_TIME_MASK;
+
+	lock = litex_clk_lookup_lock(mul - 1);
+
+	ret = litex_clk_change_value(hw, LOCK1_MASK, lock & 0x3ff, LOCK_REG1);
+	if (ret != 0)
+		return ret;
+	ret = litex_clk_change_value(hw, LOCK23_MASK,
+				(((lock >> 16) & 0x1f) << 10) | 0x1, LOCK_REG2);
+	if (ret != 0)
+		return ret;
+	ret = litex_clk_change_value(hw, LOCK23_MASK,
+			      (((lock >> 24) & 0x1f) << 10) | 0x3e9, LOCK_REG3);
+	if (ret != 0)
+		return ret;
+	return 0;
+}
+
+/*
+ * Load default global divider and multiplier values
+ *
+ */
+static int litex_clk_set_dm(struct clk_hw *clk_hw)
+{
+	int ret;
+
+	ret = litex_clk_set_divreg(clk_hw, KEEP_IN_DIV, GLOB_DIV_VAL);
+	if (ret != 0)
+		return ret;
+	ret = litex_clk_set_mulreg(clk_hw, KEEP_IN_MUL, GLOB_MUL_VAL);
+	if (ret != 0)
+		return ret;
+	ret = litex_clk_set_filt(clk_hw);
+	if (ret != 0)
+		return ret;
+	ret = litex_clk_set_lock(clk_hw);
+	if (ret != 0)
+		return ret;
+	return 0;
+}
+
+/* Round scaled value*/
+static inline u32 litex_round(u32 val, u32 mod)
+{
+	if (val % mod > mod / 2)
+		return val / mod + 1;
+	else
+		return val / mod;
+}
+
+/*
+ *	Duty Cycle
+ */
+
+/*
+ * Calculate necessary values for setting duty cycle in fractional mode
+ *
+ * divider:		frequency divider value for calculating the phase
+ * high_duty:		desired duty cycle in percent
+ * fract_cnt:		fractional frequency divider value, if not for
+ *			CLKOUT0 - set 0
+ * pointers:		function return values, used for setting desired duty
+ *
+ * This function is based on Xilinx Unified Simulation Library Component
+ * Advanced Mixed Mode Clock Manager (MMCM) taken from Xilinx Vivado
+ * found in: <Vivado-dir>/data/verilog/src/unisims/MMCME2_ADV.v
+ *
+ */
+static int litex_clk_calc_duty_fract(int divider, int high_duty, int fract_cnt,
+					u8 *edge, u8 *high_time, u8 *low_time,
+					u8 *frac_wf_r, u8 *frac_wf_f)
+{
+	int even_part_high, even_part_low, odd, odd_and_frac;
+
+			/* divider / 2 */
+	even_part_high = divider >> 1;
+	even_part_low = even_part_high;
+	odd = divider - even_part_high - even_part_low;
+	odd_and_frac = (8 * odd) + fract_cnt;
+
+	*low_time = even_part_high;
+	if (odd_and_frac <= ODD_AND_FRAC)
+		(*low_time)--;
+
+	*high_time = even_part_low;
+	if (odd_and_frac <= EVEN_AND_FRAC)
+		(*high_time)--;
+
+	*edge = divider % 2;
+
+	if (((odd_and_frac >= 2) && (odd_and_frac <= ODD_AND_FRAC)) ||
+				   ((fract_cnt == 1) && (divider == 2)))
+		*frac_wf_f = 1;
+	else
+		*frac_wf_f = 0;
+
+	if ((odd_and_frac >= 1) && (odd_and_frac <= EVEN_AND_FRAC))
+		*frac_wf_r = 1;
+	else
+		*frac_wf_r = 0;
+
+	return 0;
+}
+/* End of Vivado based code */
+
+/*
+ * Calculate necessary values for setting duty cycle in normal mode
+ *
+ * divider:		frequency divider value for calculating the phase
+ * high_duty:		desired duty cycle in percent
+ * pointers:		function return values, used for setting desired duty
+ *
+ */
+static int litex_clk_calc_duty_normal(int divider, int high_duty, u8 *edge,
+						   u8 *high_time, u8 *low_time,
+						   u8 *frac_wf_r, u8 *frac_wf_f)
+{
+	int synthetic_duty, delta_d, min_d;
+	u32 high_time_it, ht_aprox, edge_it;
+
+	min_d = INT_MAX;
+	/* check if duty is available to set */
+	ht_aprox = high_duty * divider;
+	if (ht_aprox > ((HIGH_LOW_TIME_REG_MAX * 100) + 50) ||
+					(divider * 100) - ht_aprox >
+					((HIGH_LOW_TIME_REG_MAX * 100) + 50))
+		return -EINVAL;
+
+	/* to prevent high_time == 0 or low_time == 0 */
+	for (high_time_it = 1; high_time_it < divider; high_time_it++) {
+		for (edge_it = 0; edge_it < 2; edge_it++) {
+			synthetic_duty = (high_time_it * 100 + 50 * edge_it) /
+								divider;
+			delta_d = abs(synthetic_duty - high_duty);
+			/* check if low_time won't be above acceptable range */
+			if (delta_d < min_d && (divider - high_time_it) <=
+						    HIGH_LOW_TIME_REG_MAX) {
+				min_d = delta_d;
+				*high_time = high_time_it;
+				*low_time = divider - *high_time;
+				*edge = edge_it;
+			}
+		}
+	}
+	/*
+	 * Calculating values in normal mode,
+	 * clear control bits of fractional part
+	 */
+
+	*frac_wf_f = 0;
+	*frac_wf_r = 0;
+
+	return 0;
+}
+
+/* Calculates duty cycle for given ratio in percent, 1% accuracy */
+static inline int litex_clk_calc_duty_percent(struct clk_hw *hw,
+					      struct clk_duty *duty)
+{
+	u32 div, duty_ratio, ht;
+
+	ht = duty->num;
+	div = duty->den;
+	duty_ratio = ht * 10000 / div;
+
+	return litex_round(duty_ratio, 100);
+}
+
+/* Calculates duty high_time for given divider and ratio */
+static inline int litex_clk_calc_duty_high_time(struct clk_hw *hw,
+						struct clk_duty *duty,
+						   u32 divider)
+{
+	u32 high_duty;
+
+	high_duty = litex_clk_calc_duty_percent(hw, duty) * divider;
+
+	return litex_round(high_duty, 100);
+}
+
+/* Returns accurate duty ratio of given clkout*/
+int litex_clk_get_duty_cycle(struct clk_hw *hw, struct clk_duty *duty)
+{
+	struct litex_clk_clkout *l_clkout = clk_hw_to_litex_clk_clkout(hw);
+	struct litex_clk_regs_addr drp_addr = litex_clk_regs_addr_init();
+	int ret;
+	u32 divider;
+	u16 clkout_reg1, clkout_reg2;
+	u8 clkout_nr, high_time, edge, no_cnt, frac_en, frac_cnt;
+
+	clkout_nr = l_clkout->id;
+	/* Check if divider is off */
+	ret = litex_clk_get_DO(hw, drp_addr.clkout[clkout_nr].reg2,
+						      &clkout_reg2);
+	if (ret != 0)
+		return ret;
+	edge = (clkout_reg2 >> EDGE_POS) & EDGE_MASK;
+	no_cnt = (clkout_reg2 >> NO_CNT_POS) & NO_CNT_MASK;
+	frac_en = (clkout_reg2 >> FRAC_EN_POS) & FRAC_EN_MASK;
+	frac_cnt = (clkout_reg2 >> FRAC_POS) & FRAC_MASK;
+
+	/* get duty 50% when divider is off or fractional is enabled */
+	if (no_cnt || (frac_en && frac_cnt)) {
+		duty->num = 1;
+		duty->den = 2;
+		return 0;
+	}
+
+	ret = litex_clk_get_DO(hw, drp_addr.clkout[clkout_nr].reg1,
+						      &clkout_reg1);
+	if (ret != 0)
+		return ret;
+	divider = clkout_reg1 & HL_TIME_MASK;
+	high_time = (clkout_reg1 >> HIGH_TIME_POS) & HL_TIME_MASK;
+	divider += high_time;
+
+	/* Scaling to consider edge control bit */
+	duty->num = high_time * 10 + edge * 5;
+	duty->den = (divider + edge) * 10;
+
+	return 0;
+}
+
+/* Set duty cycle with given ratio */
+int litex_clk_set_duty_cycle(struct clk_hw *hw, struct clk_duty *duty)
+{
+	struct litex_clk_clkout *l_clkout = clk_hw_to_litex_clk_clkout(hw);
+	u32 divider, fract_cnt, high_duty;
+	u16 bitset1, bitset2;
+	u8 frac_wf_r, frac_wf_f, frac_en, no_cnt,
+		edge, high_time, low_time, clkout_nr;
+
+	clkout_nr = l_clkout->id;
+	edge = 0, high_time = 0, low_time = 0, frac_en = 0,
+	no_cnt = 0, frac_wf_r = 0, frac_wf_f = 0;
+	high_duty = litex_clk_calc_duty_percent(hw, duty);
+
+	litex_clk_get_clkout_divider(hw, &divider, &fract_cnt);
+
+	if (fract_cnt == 0) {
+		int ret;
+
+		ret = litex_clk_calc_duty_normal(divider, high_duty, &edge,
+						     &high_time, &low_time,
+						    &frac_wf_r, &frac_wf_f);
+		if (ret != 0) {
+			pr_err("CLKOUT%d: cannot set %d%% duty cycle for that frequency",
+				clkout_nr, high_duty);
+			return ret;
+		}
+	} else if (high_duty == 50) {
+		return 0;
+	} else {
+		pr_err("CLKOUT%d: cannot set duty cycle when fractional divider enabled!",
+								clkout_nr);
+		return -EACCES;
+	}
+
+	bitset1 = (high_time << HIGH_TIME_POS) | low_time;
+	bitset2 = (edge << EDGE_POS);
+
+	pr_debug("SET DUTY CYCLE: divider:%d fract_cnt:%d frac_wf_r:%d frac_wf_f:%d frac_en:%d no_cnt:%d edge:%d high_time:%d low_time:%d bitset1: 0x%x bitset2: 0x%x",
+		divider, fract_cnt, frac_wf_r, frac_wf_f, frac_en,
+		no_cnt, edge, high_time, low_time, bitset1, bitset2);
+
+	return litex_clk_set_clock(hw, clkout_nr, REG1_DUTY_MASK, bitset1,
+						  REG2_DUTY_MASK, bitset2);
+}
+
+/*
+ *	Phase
+ */
+
+/*
+ * Calculate necessary values for setting phase in fractional mode
+ *
+ * clk_hw:		hardware specific clock structure
+ * divider:		frequency divider value for calculating the phase
+ * fract_cnt:		fractional frequency divider value, if not for
+ *			CLKOUT0 - set 0
+ * phase_offset:	desired phase in angle degrees
+ * pointers:		function return values, used for setting desired phase
+ *
+ * This function is based on Xilinx Unified Simulation Library Component
+ * Advanced Mixed Mode Clock Manager (MMCM) taken from Xilinx Vivado
+ * found in: <Vivado-dir>/data/verilog/src/unisims/MMCME2_ADV.v
+ *
+ */
+static int litex_clk_calc_phase_fract(struct clk_hw *hw, u32 divider,
+					u32 fract_cnt, u32 phase_offset,
+					u32 *phase_mux, u32 *delay_time,
+					u32 *phase_mux_f, u32 *period_offset)
+{
+	int phase, dt_calc, dt,
+		a_per_in_octets, a_phase_in_cycles,
+		pm_rise_frac, pm_rise_frac_filtered,
+		pm_fall, pm_fall_frac, pm_fall_frac_filtered;
+
+	phase = phase_offset * 1000;
+	a_per_in_octets = (8 * divider) + fract_cnt;
+	a_phase_in_cycles = (phase + 10) * a_per_in_octets / 360000;
+
+	if ((a_phase_in_cycles & FULL_BYTE) != 0)
+		pm_rise_frac = (a_phase_in_cycles & PHASE_MUX_MAX);
+	else
+		pm_rise_frac = 0;
+
+	dt_calc = a_phase_in_cycles / 8;
+	dt = dt_calc & FULL_BYTE;
+
+	pm_rise_frac_filtered = pm_rise_frac;
+	if (pm_rise_frac >= 8)
+		pm_rise_frac_filtered -= 8;
+
+	pm_fall = ((divider % 2) << 2) + ((fract_cnt >> 1) & TWO_LSBITS);
+	pm_fall_frac = pm_fall + pm_rise_frac;
+	pm_fall_frac_filtered = pm_fall + pm_rise_frac -
+					 (pm_fall_frac & F_FRAC_MASK);
+
+	/* keep only the lowest bits to fit in control registers bit groups */
+	*delay_time = dt % (1 << 6);
+	*phase_mux = pm_rise_frac_filtered % (1 << 3);
+	*phase_mux_f = pm_fall_frac_filtered % (1 << 3);
+
+	return 0;
+}
+/* End of Vivado based code */
+
+/*
+ * Calculate necessary values for setting phase in normal mode
+ *
+ * clk_hw:		hardware specific clock structure
+ * divider:		frequency divider value for calculating the phase
+ * fract_cnt:		fractional frequency divider value, if not for
+ *			CLKOUT0 - set 0
+ * phase_offset:	desired phase in angle degrees
+ * pointers:		function return values, used for setting desired phase
+ *
+ */
+static int litex_clk_calc_phase_normal(struct clk_hw *hw, u32 divider,
+					u32 fract_cnt, u32 phase_offset,
+					u32 *phase_mux, u32 *delay_time,
+					u32 *phase_mux_f, u32 *period_offset)
+{
+	/* ns unit */
+	u32 global_period, clkout_period, post_glob_div_f;
+
+	post_glob_div_f = litex_clk_get_real_global_frequency(hw);
+	global_period = NS_IN_SEC / post_glob_div_f;
+	clkout_period = global_period * divider;
+
+	if (phase_offset != 0) {
+		int synthetic_phase, delta_p, min_p;
+		u8 d_t, p_m;
+
+		*period_offset = litex_round(clkout_period * (*period_offset),
+								10000);
+
+		if (*period_offset / global_period > DELAY_TIME_MAX)
+			return -EINVAL;
+
+		min_p = INT_MAX;
+		/* Delay_time: (0-63) */
+		for (d_t = 0; d_t <= DELAY_TIME_MAX; d_t++) {
+			/* phase_mux: (0-7) */
+			for (p_m = 0; p_m <= PHASE_MUX_MAX; p_m++) {
+				synthetic_phase = (d_t * global_period) +
+				((p_m * ((global_period * 100) / 8) / 100));
+
+				delta_p = abs(synthetic_phase - *period_offset);
+				if (delta_p < min_p) {
+					min_p = delta_p;
+					*phase_mux = p_m;
+					*delay_time = d_t;
+				}
+			}
+		}
+	} else {
+		/* Don't change phase offset*/
+		*phase_mux = 0;
+		*delay_time = 0;
+	}
+/* Calculating values in normal mode, fractional control bits need to be zero*/
+		*phase_mux_f = 0;
+
+	return 0;
+}
+
+/*
+ * Convert phase offset to positive lower than 360 deg.
+ * and calculate period in nanoseconds
+ *
+ */
+static int litex_clk_prepare_phase(int *phase_offset, u32 *period_offset)
+{
+	*phase_offset = *phase_offset % 360;
+
+	if (*phase_offset < 0)
+		*phase_offset += 360;
+
+	*period_offset = ((*phase_offset * 10000) / 360);
+
+	return 0;
+}
+
+/*
+ * Calculate necessary values for setting phase
+ *
+ * clk_hw:		hardware specific clock structure
+ * divider:		frequency divider value for calculating the phase
+ * fract_cnt:		fractional frequency divider value, if not for
+ *			CLKOUT0 - set 0
+ * clkout_nr:		clock output number
+ * phase_offset:	desired phase in angle degrees
+ * pointers:		function return values, used for setting desired phase
+ *
+ */
+static int litex_clk_calc_phase(struct clk_hw *clk_hw,
+					u32 divider, u32 fract_cnt,
+					u32 clkout_nr, int phase_offset,
+					u32 *phase_mux, u32 *delay_time,
+					u32 *phase_mux_f, u32 *period_offset)
+{
+	int ret;
+
+	litex_clk_prepare_phase(&phase_offset, period_offset);
+
+	if (clkout_nr == 0 && fract_cnt > 0)
+		ret = litex_clk_calc_phase_fract(clk_hw, divider, fract_cnt,
+						phase_offset,
+						phase_mux, delay_time,
+						phase_mux_f, period_offset);
+	else
+		ret = litex_clk_calc_phase_normal(clk_hw, divider, fract_cnt,
+						phase_offset,
+						phase_mux, delay_time,
+						phase_mux_f, period_offset);
+	return ret;
+}
+
+/* Returns phase-specific values of given clock output */
+static int litex_clk_get_phase_data(struct clk_hw *hw, u8 *phase_mux,
+				       u8 *delay_time, u8 *phase_mux_f)
+{
+	struct litex_clk_clkout *l_clkout = clk_hw_to_litex_clk_clkout(hw);
+	struct litex_clk_regs_addr drp_addr = litex_clk_regs_addr_init();
+	int ret;
+	u16 r1, r2;
+	u8 clkout_nr = l_clkout->id;
+
+	ret = litex_clk_get_DO(hw, drp_addr.clkout[clkout_nr].reg1, &r1);
+	if (ret != 0)
+		return ret;
+	ret = litex_clk_get_DO(hw, drp_addr.clkout[clkout_nr].reg2, &r2);
+	if (ret != 0)
+		return ret;
+	*phase_mux = (r1 >> PHASE_MUX_POS) & PHASE_MUX_MASK;
+	*delay_time = (r2 >> DELAY_TIME_POS) & HL_TIME_MASK;
+
+	if (clkout_nr == 0) {
+		ret = litex_clk_get_DO(hw, CLKOUT5_REG2, &r2);
+		if (ret != 0)
+			return ret;
+		*phase_mux_f = (r2 >> PHASE_MUX_F_POS) & PHASE_MUX_F_MASK;
+	} else {
+		*phase_mux_f = 0;
+	}
+
+	return 0;
+}
+
+/* Returns phase of given clock output in degrees */
+int litex_clk_get_phase(struct clk_hw *hw)
+{
+	u8 phase_mux = 0, delay_time = 0, phase_mux_f;
+	u32 divider, fract_cnt, post_glob_div_f, pm;
+	/* ns unit */
+	u32 global_period, clkout_period, period;
+
+	litex_clk_get_phase_data(hw, &phase_mux, &delay_time, &phase_mux_f);
+	litex_clk_get_clkout_divider(hw, &divider, &fract_cnt);
+
+	post_glob_div_f = litex_clk_get_real_global_frequency(hw);
+	global_period = NS_IN_SEC / post_glob_div_f;
+	clkout_period = global_period * divider;
+
+	pm = (phase_mux * global_period * 1000) / PHASE_MUX_RES_FACTOR;
+	pm = litex_round(pm, 1000);
+
+	period = delay_time * global_period + pm;
+
+	period = period * 1000 / clkout_period;
+	period = period * 360;
+
+	return litex_round(period, 1000);
+}
+
+/* Sets phase given in degrees on given clock output */
+int litex_clk_set_phase(struct clk_hw *hw, int degrees)
+{
+	struct litex_clk_clkout *l_clkout = clk_hw_to_litex_clk_clkout(hw);
+	u32 phase_mux, divider, fract_cnt,
+	    phase_mux_f, delay_time, period_offset;
+	u16 bitset1, bitset2, reg2_mask;
+	u8 clkout_nr, edge, high_time, low_time, frac_wf_r, frac_wf_f;
+	int ret;
+
+	reg2_mask = REG2_PHASE_MASK;
+	phase_mux = 0;
+	delay_time = 0;
+	clkout_nr = l_clkout->id;
+	litex_clk_get_clkout_divider(hw, &divider, &fract_cnt);
+	if (fract_cnt > 0 && degrees != 0) {
+		pr_err("CLKOUT%d: cannot set phase on that frequency",
+								clkout_nr);
+		return -ENOSYS;
+	}
+	ret = litex_clk_calc_phase(hw, divider, fract_cnt, clkout_nr, degrees,
+						&phase_mux, &delay_time,
+						&phase_mux_f, &period_offset);
+	if (ret != 0) {
+		pr_err("CLKOUT%d: phase offset %d deg is too high for given frequency",
+							clkout_nr, degrees);
+		return ret;
+	}
+
+	bitset1 = (phase_mux << PHASE_MUX_POS);
+	bitset2 = (delay_time << DELAY_TIME_POS);
+
+	if (clkout_nr == 0 && fract_cnt > 0) {
+		u16 clkout5_reg2_bitset;
+
+		litex_clk_calc_duty_fract(divider, 50, fract_cnt,
+						&edge, &high_time, &low_time,
+						&frac_wf_r, &frac_wf_f);
+		bitset2 |= (fract_cnt << FRAC_POS)	|
+			   (1 << FRAC_EN_POS)		|
+			   (frac_wf_r << FRAC_WF_R_POS);
+
+		clkout5_reg2_bitset = (phase_mux_f << PHASE_MUX_F_POS)	|
+				      (frac_wf_f << FRAC_WF_F_POS);
+
+		ret = litex_clk_change_value(hw, CLKOUT5_FRAC_MASK,
+					   clkout5_reg2_bitset,
+					   CLKOUT5_REG2);
+		if (ret != 0)
+			return ret;
+		reg2_mask = REG2_PHASE_F_MASK;
+	}
+
+	pr_debug("SET PHASE: phase_mux:%d phase_mux_f:%d delay_time:%d bitset1: 0x%x bitset2: 0x%x",
+		phase_mux, phase_mux_f, delay_time, bitset1, bitset2);
+
+	return litex_clk_set_clock(hw, clkout_nr, REG1_PHASE_MASK, bitset1,
+						 reg2_mask, bitset2);
+}
+
+/*
+ *	Frequency
+ */
+
+/*
+ * Calculate necessary values for setting frequency in fractional mode
+ *
+ * clk_hw:		hardware specific clock structure
+ * freq:		desired frequency in Hz
+ * pointers:		function return values, used for setting
+ *			desired frequency
+ */
+static int litex_clk_calc_freq_fract(struct clk_hw *clk_hw, u32 freq,
+						u32 *divider, u8 *frac_en,
+						u8 *no_cnt, u32 *fract_cnt)
+{
+	int delta_f, synthetic_freq, min_f;
+	u32 post_glob_div_f, div, f_cnt, fract;
+
+	post_glob_div_f = litex_clk_get_real_global_frequency(clk_hw);
+
+	delta_f = 0;
+	synthetic_freq = post_glob_div_f;
+	min_f = abs(synthetic_freq - freq);
+	*divider = 1;
+	/* div is integer divider * 1000 to keep precision */
+	for (div = MIN_DIVIDER_F; div <= MAX_DIVIDER_F; div += 1000) {
+		/*
+		 * f_cnt is fractional part of divider * 1000 incremented
+		 * by minimal fractional divider step to keep precision
+		 * and find best divider
+		 */
+		for (f_cnt = 0, fract = 0; fract < 1000;
+				fract += FRACT_DIV_RES, f_cnt++) {
+
+			synthetic_freq = (post_glob_div_f / (div + fract)) *
+								       1000;
+			delta_f = abs(synthetic_freq - freq);
+
+			if (delta_f < min_f) {
+				min_f = delta_f;
+				*divider = div / 1000;
+				*fract_cnt = f_cnt;
+			}
+		}
+	}
+	if (*fract_cnt == 0) {
+		*frac_en = 0;
+		if (*divider == 1)
+			*no_cnt = 1;
+		else
+			*no_cnt = 0;
+	} else {
+		*frac_en = 1;
+		*no_cnt = 0;
+	}
+
+	return 0;
+}
+
+/*
+ * Calculate necessary values for setting frequency in normal mode
+ *
+ * clk_hw:		hardware specific clock structure
+ * freq:		desired frequency in Hz
+ * pointers:		function return values, used for setting
+ *			desired frequency
+ *
+ */
+static int litex_clk_calc_freq_normal(struct clk_hw *clk_hw, u32 freq,
+						u32 *divider, u8 *frac_en,
+						u8 *no_cnt, u32 *fract_cnt)
+{
+	int delta_f, synthetic_freq, min_f;
+	u32 post_glob_div_f, div;
+
+	post_glob_div_f = litex_clk_get_real_global_frequency(clk_hw);
+	synthetic_freq = post_glob_div_f;
+	min_f = abs(synthetic_freq - freq);
+	*divider = 1;
+	delta_f = 0;
+
+	for (div = MIN_DIVIDER; div <= MAX_DIVIDER; div++) {
+		synthetic_freq = post_glob_div_f / div;
+		delta_f = abs(synthetic_freq - freq);
+		if (delta_f < min_f) {
+			min_f = delta_f;
+			*divider = div;
+		}
+	}
+	if (*divider == 1)
+		*no_cnt = 1;
+	else
+		*no_cnt = 0;
+
+	*frac_en = 0;
+	*fract_cnt = 0;
+
+	return 0;
+}
+
+/* Returns rate in Hz */
+static inline unsigned long litex_clk_calc_rate(struct clk_hw *hw, u32 g_mul,
+							u32 g_div, u32 div,
+							u32 fract_cnt)
+{
+	struct litex_clk_clkout *l_clkout = clk_hw_to_litex_clk_clkout(hw);
+
+	return (l_clkout->sys_clk_freq * g_mul /
+	      ((div * 1000 + (fract_cnt * FRACT_DIV_RES)) * g_div)) * 1000;
+}
+
+/*
+ * Calculate necessary values for setting frequency
+ *
+ * clk_hw:		hardware specific clock structure
+ * rate:		desired frequency in Hz
+ * clkout_nr:		clock output number
+ * pointers:		function return values, used for setting
+ *			desired frequency
+ *
+ */
+static void litex_clk_calc_dividers(struct clk_hw *hw, u32 rate, u8 clkout_nr,
+					u32 *divider, u32 *fract_cnt,
+					u8 *frac_wf_r, u8 *frac_wf_f,
+					u8 *frac_en, u8 *no_cnt, u8 *edge,
+					u8 *high_time, u8 *low_time)
+{
+	u32 high_duty;
+	struct clk_duty duty;
+
+	litex_clk_get_duty_cycle(hw, &duty);
+	high_duty = litex_clk_calc_duty_percent(hw, &duty);
+
+	if (clkout_nr == 0) {
+		litex_clk_calc_freq_fract(hw, rate, divider, frac_en, no_cnt,
+								   fract_cnt);
+		if (*fract_cnt > 0)
+			litex_clk_calc_duty_fract(*divider, high_duty,
+						  *fract_cnt, edge,
+						   high_time, low_time,
+						   frac_wf_r, frac_wf_f);
+		else
+			litex_clk_calc_duty_normal(*divider, high_duty, edge,
+						    high_time, low_time,
+						    frac_wf_r, frac_wf_f);
+	} else {
+
+		litex_clk_calc_freq_normal(hw, rate, divider, frac_en,
+						     no_cnt, fract_cnt);
+
+		litex_clk_calc_duty_normal(*divider, high_duty, edge,
+						     high_time, low_time,
+						     frac_wf_r, frac_wf_f);
+	}
+}
+
+/* Returns rate of given CLKOUT, parent_rate ignored */
+unsigned long litex_clk_recalc_rate(struct clk_hw *hw,
+				    unsigned long parent_rate)
+{
+	u32 multiplier, divider, clkout_div, fract_cnt;
+
+	LITEX_UNUSED(parent_rate);
+
+	litex_clk_get_global_divider(hw, &divider, &multiplier);
+	litex_clk_get_clkout_divider(hw, &clkout_div, &fract_cnt);
+	return litex_clk_calc_rate(hw, multiplier, divider, clkout_div,
+							     fract_cnt);
+}
+
+int litex_clk_check_rate_range(struct clk_hw *hw, unsigned long rate)
+{
+	u32 f_max, f_min, gf;
+
+	gf = litex_clk_get_real_global_frequency(hw);
+	f_max = gf / 2;
+	f_min = gf / MAX_DIVIDER;
+	/* margin of 1kHz */
+	if ((rate > f_max + KHZ) | (rate < f_min - KHZ))
+		return -EINVAL;
+
+	return 0;
+}
+
+/* Returns closest available clock rate in Hz, parent_rate ignored */
+long litex_clk_round_rate(struct clk_hw *hw, unsigned long rate,
+					     unsigned long *parent_rate)
+{
+	struct litex_clk_clkout *l_clkout = clk_hw_to_litex_clk_clkout(hw);
+	u32 divider, fract_cnt, g_divider, g_multiplier;
+	u8 frac_wf_r, frac_wf_f, frac_en, no_cnt,
+		edge, high_time, low_time, clkout_nr;
+
+	if (litex_clk_check_rate_range(hw, rate))
+		return -EINVAL;
+
+	LITEX_UNUSED(parent_rate);
+	clkout_nr = l_clkout->id;
+
+	litex_clk_calc_dividers(hw, rate, clkout_nr, &divider, &fract_cnt,
+				&frac_wf_r, &frac_wf_f, &frac_en,
+				&no_cnt, &edge, &high_time, &low_time);
+	litex_clk_get_global_divider(hw, &g_divider, &g_multiplier);
+
+	return litex_clk_calc_rate(hw, g_multiplier, g_divider, divider,
+								fract_cnt);
+}
+
+/* Set closest available clock rate in Hz, parent_rate ignored */
+int litex_clk_set_rate(struct clk_hw *hw, unsigned long rate,
+					  unsigned long parent_rate)
+{
+	struct litex_clk_clkout *l_clkout = clk_hw_to_litex_clk_clkout(hw);
+	u16 bitset1, bitset2;
+	u32 divider, fract_cnt;
+	u8 frac_wf_r, frac_wf_f, frac_en, no_cnt,
+		edge, high_time, low_time, clkout_nr;
+	int ret;
+
+	LITEX_UNUSED(parent_rate);
+	clkout_nr = l_clkout->id;
+
+	pr_debug("set_rate: %lu", rate);
+	if (litex_clk_check_rate_range(hw, rate)) {
+		pr_err("CLKOUT%d: cannot set %luHz, frequency not in available range",
+							clkout_nr, rate);
+		return -EINVAL;
+	}
+
+	litex_clk_calc_dividers(hw, rate, clkout_nr, &divider, &fract_cnt,
+				&frac_wf_r, &frac_wf_f, &frac_en, &no_cnt,
+					    &edge, &high_time, &low_time);
+
+	bitset1 = (high_time << HIGH_TIME_POS)	|
+		  (low_time << LOW_TIME_POS);
+
+	bitset2 = (fract_cnt << FRAC_POS)	|
+		  (frac_en << FRAC_EN_POS)	|
+		  (frac_wf_r << FRAC_WF_R_POS)	|
+		  (edge << EDGE_POS)		|
+		  (no_cnt << NO_CNT_POS);
+	if (frac_en != 0) {
+		u32 phase_mux, delay_time, phase_mux_f,
+		    phase_offset, period_offset;
+
+		phase_offset = 0;
+		litex_clk_calc_phase_fract(hw, divider, fract_cnt, phase_offset,
+					       &phase_mux, &delay_time,
+					       &phase_mux_f, &period_offset);
+
+		bitset1 |= (phase_mux << PHASE_MUX_POS);
+		bitset2 |= (delay_time << DELAY_TIME_POS);
+
+		if (frac_wf_f > 0 || phase_mux_f > 0) {
+			u16 clkout5_reg2_bitset = 0;
+
+			clkout5_reg2_bitset = (phase_mux_f << PHASE_MUX_F_POS) |
+					      (frac_wf_f << FRAC_WF_F_POS);
+
+			ret = litex_clk_change_value(hw, CLKOUT5_FRAC_MASK,
+				    clkout5_reg2_bitset, CLKOUT5_REG2);
+			if (ret != 0)
+				return ret;
+		}
+	}
+
+	pr_debug("SET RATE: divider:%d fract_cnt:%d frac_wf_r:%d frac_wf_f:%d frac_en:%d no_cnt:%d edge:%d high_time:%d low_time:%d bitset1: 0x%x bitset2: 0x%x",
+		divider, fract_cnt, frac_wf_r, frac_wf_f, frac_en,
+		no_cnt, edge, high_time, low_time, bitset1, bitset2);
+
+	return litex_clk_set_clock(hw, clkout_nr, REG1_FREQ_MASK, bitset1,
+						  REG2_FREQ_MASK, bitset2);
+}
+
+/* Prepare clock output */
+int litex_clk_prepare(struct clk_hw *hw)
+{
+	struct litex_clk_clkout *l_clkout;
+	struct clk_duty duty;
+	u32 freq, phase;
+
+	l_clkout = clk_hw_to_litex_clk_clkout(hw);
+	freq = l_clkout->default_freq;
+	phase = l_clkout->default_phase;
+	duty.num = l_clkout->default_duty_num;
+	duty.den = l_clkout->default_duty_den;
+
+	litex_clk_set_rate(hw, freq, 0);
+	litex_clk_set_duty_cycle(hw, &duty);
+	litex_clk_set_phase(hw, phase);
+	return 0;
+}
+
+/* Unrepare clock output */
+void litex_clk_unprepare(struct clk_hw *hw)
+{
+	struct clk_duty duty;
+
+	duty.num = 1;
+	duty.den = 2;
+	litex_clk_set_rate(hw, 100000000, 0);
+	litex_clk_set_duty_cycle(hw, &duty);
+	litex_clk_set_phase(hw, 0);
+}
+
+/* Enable Clock Control MMCM module */
+int litex_clk_enable(struct clk_hw *hw)
+{
+	litex_clk_assert_reg(hw, DRP_RESET);
+	return 0;
+}
+
+/* Disable Clock Control MMCM module */
+void litex_clk_disable(struct clk_hw *hw)
+{
+	litex_clk_deassert_reg(hw, DRP_RESET);
+}
+
+/* Set default clock value from device tree for given clkout*/
+static int litex_clk_set_def_clkout(struct clk_hw *hw, u32 freq, u32 phase,
+							struct clk_duty *duty)
+{
+	int ret;
+
+	ret = litex_clk_set_rate(hw, freq, 0);
+	if (ret != 0)
+		return ret;
+	ret = litex_clk_set_duty_cycle(hw, duty);
+	if (ret != 0)
+		return ret;
+	ret = litex_clk_set_phase(hw, phase);
+	if (ret != 0)
+		return ret;
+	return 0;
+}
+
+static const struct clk_ops litex_clk_ops = {
+	.prepare		=	litex_clk_prepare,
+	.unprepare		=	litex_clk_unprepare,
+	.enable			=	litex_clk_enable,
+	.disable		=	litex_clk_disable,
+	.recalc_rate		=	litex_clk_recalc_rate,
+	.round_rate		=	litex_clk_round_rate,
+	.set_rate		=	litex_clk_set_rate,
+	.get_phase		=	litex_clk_get_phase,
+	.set_phase		=	litex_clk_set_phase,
+	.get_duty_cycle		=	litex_clk_get_duty_cycle,
+	.set_duty_cycle		=	litex_clk_set_duty_cycle,
+};
+
+static const struct of_device_id litex_of_match[] = {
+	{.compatible = "litex,clk"},
+	{},
+};
+
+MODULE_DEVICE_TABLE(of, litex_of_match);
+
+static int litex_clk_read_clkout_dts(struct device_node *child,
+				     struct litex_clk_clkout *clkout)
+{
+	int ret;
+	u32 dt_num, dt_freq, dt_phase, dt_duty_num,
+	    dt_duty_den, f_max, f_min, gf;
+
+	gf = litex_clk_get_expctd_global_frequency(clkout->sys_clk_freq);
+	f_max = gf / 2;
+	f_min = gf / MAX_DIVIDER;
+
+	ret = of_property_read_u32(child, "reg", &dt_num);
+	if (ret != 0)
+		return -ret;
+
+	if (dt_num > CLKOUT_MAX) {
+		pr_err("%s: Invalid CLKOUT index!", child->name);
+		return -EINVAL;
+	}
+
+	ret = of_property_read_u32(child, "litex,clock-frequency", &dt_freq);
+	if (ret != 0)
+		return -ret;
+
+	if (dt_freq > f_max || dt_freq < f_min) {
+		pr_err("%s: Invalid default frequency!(%d), MIN/MAX (%d/%d)Hz",
+			child->name, dt_freq, f_min, f_max);
+		return -EINVAL;
+	}
+
+	ret = of_property_read_u32(child, "litex,clock-phase", &dt_phase);
+	if (ret != 0)
+		return -ret;
+
+	ret = of_property_read_u32(child, "litex,clock-duty-den", &dt_duty_den);
+	if (ret != 0)
+		return -ret;
+
+	ret = of_property_read_u32(child, "litex,clock-duty-num", &dt_duty_num);
+	if (ret != 0)
+		return -ret;
+
+	if (dt_duty_den <= 0 || dt_duty_num > dt_duty_den) {
+		pr_err("%s: Invalid default duty! %d/%d", child->name,
+						dt_duty_num, dt_duty_den);
+		return -EINVAL;
+	}
+
+	clkout->id = dt_num;
+	clkout->default_freq = dt_freq;
+	clkout->default_phase = dt_phase;
+	clkout->default_duty_num = dt_duty_num;
+	clkout->default_duty_den = dt_duty_den;
+
+	return 0;
+}
+
+static int litex_clk_get_timeouts(struct device_node *node, int *dt_lock_timeout,
+							    int *dt_drdy_timeout)
+{
+	int ret;
+
+	/* Read wait_lock timeout from device property*/
+	ret = of_property_read_u32(node, "litex,lock-timeout", dt_lock_timeout);
+	if (ret < 0) {
+		pr_err("No litex,lock_timeout entry in the dts file\n");
+		return -ENODEV;
+	}
+	if (*dt_lock_timeout < 1) {
+		pr_err("LiteX CLK driver cannot wait for time bellow ca. 1ms\n");
+		return -EINVAL;
+	}
+
+	/* Read wait_drdy timeout from device property*/
+	ret = of_property_read_u32(node, "litex,drdy-timeout", dt_drdy_timeout);
+	if (ret < 0) {
+		pr_err("No litex,lock_drdy entry in the dts file\n");
+		return -ENODEV;
+	}
+	if (*dt_drdy_timeout < 1) {
+		pr_err("LiteX CLK driver cannot wait for time bellow ca. 1ms\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int litex_clk_init_clkouts(struct device *dev,
+				  struct device_node *node,
+				  struct litex_clk_device *l_dev)
+{
+	struct device_node *child_node;
+	struct clk_hw *hw;
+	struct clk_duty duty;
+	u32 dt_lock_timeout, dt_drdy_timeout;
+	int i = 0, ret;
+
+	ret = litex_clk_get_timeouts(node, &dt_lock_timeout, &dt_drdy_timeout);
+	if (ret != 0)
+		return ret;
+
+	for_each_child_of_node(node, child_node) {
+		struct litex_clk_clkout *clkout;
+		struct clk_init_data clkout_init;
+
+		clkout = &l_dev->clkouts[i];
+		clkout->is_clkout = true;
+
+		clkout->lock_timeout = dt_lock_timeout;
+		clkout->drdy_timeout = dt_drdy_timeout;
+		clkout->sys_clk_freq = l_dev->sys_clk_freq;
+
+		ret = litex_clk_read_clkout_dts(child_node, clkout);
+		if (ret != 0)
+			return ret;
+
+		clkout_init.name = child_node->name;
+		clkout_init.ops = &litex_clk_ops;
+		clkout_init.num_parents = 0;
+		clkout_init.flags = CLK_SET_RATE_UNGATE | CLK_GET_RATE_NOCACHE;
+		clkout->clk_hw.init = &clkout_init;
+		clkout->base = l_dev->base;
+
+		duty.num = clkout->default_duty_num;
+		duty.den = clkout->default_duty_den;
+
+		/* set global divider and multiplier once */
+		if (i == 0) {
+			hw = &l_dev->clkouts[i].clk_hw;
+			litex_clk_enable(hw);
+			ret = litex_clk_set_dm(hw);
+			litex_clk_disable(hw);
+			if (ret != 0)
+				return ret;
+		}
+
+		ret = litex_clk_set_def_clkout(&clkout->clk_hw,
+						clkout->default_freq,
+						clkout->default_phase, &duty);
+		ret = devm_clk_hw_register(dev, &clkout->clk_hw);
+		if (ret != 0) {
+			pr_err("devm_clk_hw_register failure, %s ret: %d\n",
+						child_node->name, ret);
+			return ret;
+		}
+
+		ret = of_clk_add_hw_provider(child_node, of_clk_hw_simple_get,
+							     &clkout->clk_hw);
+		if (ret != 0)
+			return ret;
+		i++;
+	}
+	return 0;
+}
+
+static int litex_clk_read_global_dts(struct device *dev,
+				     struct device_node *node,
+				     struct litex_clk_device *l_dev)
+{
+	struct device_node *child_node;
+	struct litex_clk_clkout *l_clkout;
+	u32 dt_nclkout, dt_lock_timeout, dt_drdy_timeout, dt_sys_clk_freq;
+	int i = 0, ret;
+
+	ret = of_property_read_u32(node, "litex,sys-clock-frequency",
+						&dt_sys_clk_freq);
+	if (ret < 0) {
+		pr_err("No clock-frequency entry in the dts file\n");
+		return -ENODEV;
+	}
+	l_dev->sys_clk_freq = dt_sys_clk_freq;
+
+	/* Read cnt of CLKOUTs from device property*/
+	ret = of_property_read_u32(node, "litex,nclkout", &dt_nclkout);
+	if (ret < 0) {
+		pr_err("No litex,nclkout entry in the dts file\n");
+		return -ENODEV;
+	}
+	if (dt_nclkout > CLKOUT_MAX) {
+		pr_err("LiteX CLK driver cannot use more than %d clock outputs\n",
+								CLKOUT_MAX);
+		return -EINVAL;
+	}
+	l_dev->nclkout = dt_nclkout;
+
+	/* count existing CLKOUTs */
+	for_each_child_of_node(node, child_node)
+		i++;
+	if (i != dt_nclkout) {
+		pr_err("nclkout(%d) not matching actual CLKOUT count(%d)!",
+								dt_nclkout, i);
+		return -EINVAL;
+	}
+
+	l_dev->clkouts = devm_kzalloc(dev, sizeof(*l_clkout) * i, GFP_KERNEL);
+	if (!l_dev->clkouts) {
+		pr_err("CLKOUT memory allocation failure!");
+		return -ENOMEM;
+	}
+
+	ret = litex_clk_get_timeouts(node, &dt_lock_timeout, &dt_drdy_timeout);
+	if (ret != 0)
+		return ret;
+	l_dev->lock_timeout = dt_lock_timeout;
+	l_dev->drdy_timeout = dt_drdy_timeout;
+
+	return 0;
+}
+
+static int litex_clk_init_glob_clk(struct device *dev,
+				   struct device_node *node,
+				   struct litex_clk_device *l_dev)
+{
+	struct clk_init_data init;
+	struct clk_hw *hw;
+	int ret;
+
+	init.name = node->name;
+	init.ops = &litex_clk_ops;
+	init.flags = CLK_SET_RATE_UNGATE;
+
+	hw = &l_dev->clk_hw;
+	hw->init = &init;
+
+	ret = devm_clk_hw_register(dev, hw);
+	if (ret != 0) {
+		pr_err("devm_clk_hw_register failure, ret: %d\n", ret);
+		return ret;
+	}
+
+	ret = of_clk_add_hw_provider(node, of_clk_hw_simple_get, hw);
+	if (ret != 0) {
+		pr_err("of_clk_add_hw_provider failure, ret: %d", ret);
+		return ret;
+	}
+
+	/* Power on MMCM module */
+	ret = litex_clk_change_value(hw, FULL_REG_16, FULL_REG_16, POWER_REG);
+	if (ret != 0) {
+		pr_err("MMCM initialization failure, ret: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int litex_clk_probe(struct platform_device *pdev)
+{
+	const struct of_device_id *id;
+	struct device *dev;
+	struct device_node *node;
+	struct litex_clk_device *litex_clk_device;
+	struct resource *res;
+	int ret;
+
+	dev = &pdev->dev;
+	node = dev->of_node;
+	if (!node)
+		return -ENODEV;
+
+	id = of_match_node(litex_of_match, node);
+	if (!id)
+		return -ENODEV;
+
+	litex_clk_device = devm_kzalloc(dev, sizeof(*litex_clk_device),
+								GFP_KERNEL);
+	if (IS_ERR_OR_NULL(litex_clk_device))
+		return -ENOMEM;
+	litex_clk_device->is_clkout = false;
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	if (IS_ERR_OR_NULL(res))
+		return -EBUSY;
+
+	litex_clk_device->base = devm_of_iomap(dev, node, 0, &res->end);
+	if (IS_ERR_OR_NULL(litex_clk_device->base))
+		return -EIO;
+
+	ret = litex_clk_read_global_dts(dev, node, litex_clk_device);
+	if (ret != 0)
+		return ret;
+
+	ret = litex_clk_init_clkouts(dev, node, litex_clk_device);
+	if (ret != 0)
+		return ret;
+
+	ret = litex_clk_init_glob_clk(dev, node, litex_clk_device);
+	if (ret != 0)
+		return ret;
+
+	pr_info("litex clk control driver initialized");
+	return 0;
+}
+
+static int litex_clk_remove(struct platform_device *pdev)
+{
+	of_clk_del_provider(pdev->dev.of_node);
+	return 0;
+}
+
+static struct platform_driver litex_clk_driver = {
+	.driver = {
+		.name = "litex-clk",
+		.of_match_table = of_match_ptr(litex_of_match),
+	},
+	.probe = litex_clk_probe,
+	.remove = litex_clk_remove,
+};
+
+module_platform_driver(litex_clk_driver);
+MODULE_DESCRIPTION("LiteX clock driver");
+MODULE_AUTHOR("Antmicro <www.antmicro.com>");
+MODULE_LICENSE("GPL v2");

--- a/drivers/clk/clk-litex.h
+++ b/drivers/clk/clk-litex.h
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+#define LITEX_UNUSED(var)         (void)(var)
+
+/* Common values */
+#define NS_IN_SEC		1000000000
+#define FULL_BYTE		0xFF
+#define KHZ			1000
+
+/* MMCM specific numbers */
+#define CLKOUT_MAX		7
+#define DELAY_TIME_MAX		63
+#define PHASE_MUX_MAX		7
+#define HIGH_LOW_TIME_SAFE_MAX	62
+#define HIGH_LOW_TIME_REG_MAX	63
+#define MAX_DIVIDER		126
+#define MAX_DIVIDER_F		126000
+#define MIN_DIVIDER		2
+#define MIN_DIVIDER_F		2000
+#define PHASE_MUX_RES_FACTOR	8
+/* Fractional divider resolution multiplied by 1000 to keep precision */
+#define FRACT_DIV_RES		125
+/* Minimal value when div is odd and fract is on */
+#define ODD_AND_FRAC		9
+/* Odd div and no frac or even div and enabled fract max value */
+#define EVEN_AND_FRAC		8
+
+/* DRP registers index */
+/* Additional register */
+#define MMCM			0
+/* DRP registers */
+#define DRP_RESET		0
+#define DRP_READ		1
+#define DRP_WRITE		2
+#define DRP_DRDY		3
+#define DRP_ADR			4
+#define DRP_DAT_W		5
+#define DRP_DAT_R		6
+#define DRP_LOCKED		7
+
+/* Register space offsets */
+#define DRP_OF_RESET		0x0
+#define DRP_OF_LOCKED		0x4
+#define DRP_OF_READ		0x8
+#define DRP_OF_WRITE		0xc
+#define DRP_OF_DRDY		0x10
+#define DRP_OF_ADR		0x14
+#define DRP_OF_DAT_W		0x18
+#define DRP_OF_DAT_R		0x20
+
+/* Register sizes */
+#define DRP_SIZE_RESET		0x1
+#define DRP_SIZE_READ		0x1
+#define DRP_SIZE_WRITE		0x1
+#define DRP_SIZE_DRDY		0x1
+#define DRP_SIZE_ADR		0x1
+#define DRP_SIZE_DAT_W		0x2
+#define DRP_SIZE_DAT_R		0x2
+#define DRP_SIZE_LOCKED		0x1
+
+/* Register values */
+#define GLOB_DIV_VAL		0x41
+#define GLOB_MUL_VAL		0x82
+#define FULL_REG_16		0xFFFF
+#define KEEP_REG_16		FULL_REG_16
+#define KEEP_IN_MUL		0xF000
+#define KEEP_IN_DIV		0xE000
+#define ZERO_REG		0x0
+#define REG1_MASK		0x1000
+#define REG2_MASK		0x8000
+#define REG1_BITSET		0x41
+#define REG2_BITSET		0x40
+#define CLKOUT5_FRAC_MASK	0xC3FF
+#define CLKOUT5_FRAC_MASK_F	0xFBFF
+#define CLKOUT5_FRAC_MASK_P	0xC7FF
+#define REG1_FREQ_MASK		0xF000
+#define REG2_FREQ_MASK		0x803F
+#define REG1_DUTY_MASK		0xF000
+#define REG2_DUTY_MASK		0xFF7F
+#define REG1_PHASE_MASK		0x1FFF
+#define REG2_PHASE_MASK		0xFCC0
+#define REG2_PHASE_F_MASK	0x80C0
+#define FILT_MASK		0x9900
+#define LOCK1_MASK		0x03FF
+#define LOCK23_MASK		0x7FFF
+/* Control bits extraction masks */
+#define HL_TIME_MASK		0x3F
+#define FRAC_MASK		0x7
+#define EDGE_MASK		0x1
+#define NO_CNT_MASK		0x1
+#define FRAC_EN_MASK		0x1
+#define PHASE_MUX_MASK		0x7
+#define PHASE_MUX_F_MASK	0x7
+#define F_FRAC_MASK		0xF8
+#define TWO_LSBITS		0x3
+
+/* Bit groups start position in DRP registers */
+#define HIGH_TIME_POS		6
+#define LOW_TIME_POS		0
+#define PHASE_MUX_POS		13
+#define PHASE_MUX_F_POS		11
+#define FRAC_POS		12
+#define FRAC_EN_POS		11
+#define FRAC_WF_R_POS		10
+#define FRAC_WF_F_POS		10
+#define EDGE_POS		7
+#define NO_CNT_POS		6
+#define DELAY_TIME_POS		0
+
+/* MMCM Register addresses */
+#define POWER_REG		0x28
+#define DIV_REG			0x16
+#define LOCK_REG1		0x18
+#define LOCK_REG2		0x19
+#define LOCK_REG3		0x1A
+#define FILT_REG1		0x4E
+#define FILT_REG2		0x4F
+#define CLKOUT0_REG1		0x08
+#define CLKOUT0_REG2		0x09
+#define CLKOUT1_REG1		0x0A
+#define CLKOUT1_REG2		0x0B
+#define CLKOUT2_REG1		0x0C
+#define CLKOUT2_REG2		0x0D
+#define CLKOUT3_REG1		0x0E
+#define CLKOUT3_REG2		0x0F
+#define CLKOUT4_REG1		0x10
+#define CLKOUT4_REG2		0x11
+#define CLKOUT5_REG1		0x06
+#define CLKOUT5_REG2		0x07
+#define CLKOUT6_REG1		0x12
+#define CLKOUT6_REG2		0x13
+#define CLKFBOUT_REG1		0x14
+#define CLKFBOUT_REG2		0x15

--- a/drivers/fpga/litex-fpga.c
+++ b/drivers/fpga/litex-fpga.c
@@ -165,14 +165,14 @@ static int litex_fpga_probe(struct platform_device *pdev)
 	if (IS_ERR_OR_NULL(fpga_s->membase))
 		return -EIO;
 
-	mgr = devm_fpga_mgr_create(&pdev->dev,
-				   "LiteX ICAPBitstream FPGA Manager",
-				   &litex_fpga_manager_ops, fpga_s);
-	if (!mgr)
-		return -ENOMEM;
+	mgr = devm_fpga_mgr_register(&pdev->dev,
+				     "LiteX ICAPBitstream FPGA Manager",
+				     &litex_fpga_manager_ops, fpga_s);
+	if (IS_ERR(mgr))
+		return PTR_ERR(mgr);
 
 	platform_set_drvdata(pdev, mgr);
-	return fpga_mgr_register(mgr);
+	return 0;
 }
 
 static const struct of_device_id litex_of_match[] = {

--- a/drivers/gpu/drm/Kconfig
+++ b/drivers/gpu/drm/Kconfig
@@ -390,6 +390,8 @@ source "drivers/gpu/drm/gud/Kconfig"
 
 source "drivers/gpu/drm/sprd/Kconfig"
 
+source "drivers/gpu/drm/litevideo/Kconfig"
+
 config DRM_HYPERV
 	tristate "DRM Support for Hyper-V synthetic video device"
 	depends on DRM && PCI && MMU && HYPERV

--- a/drivers/gpu/drm/Makefile
+++ b/drivers/gpu/drm/Makefile
@@ -135,3 +135,4 @@ obj-y			+= xlnx/
 obj-y			+= gud/
 obj-$(CONFIG_DRM_HYPERV) += hyperv/
 obj-$(CONFIG_DRM_SPRD) += sprd/
+obj-$(CONFIG_DRM_LITEVIDEO) += litevideo/

--- a/drivers/gpu/drm/litevideo/Kconfig
+++ b/drivers/gpu/drm/litevideo/Kconfig
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0
+
+# Copyright (C) 2020 Antmicro <www.antmicro.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+config DRM_LITEVIDEO
+	tristate "LiteVideo support"
+	depends on DRM && LITEX_SOC_CONTROLLER
+	help
+	  This enables DRM driver for LiteX LiteVideo.

--- a/drivers/gpu/drm/litevideo/Makefile
+++ b/drivers/gpu/drm/litevideo/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0
+
+obj-$(CONFIG_DRM_LITEVIDEO) += litevideo.o

--- a/drivers/gpu/drm/litevideo/litevideo.c
+++ b/drivers/gpu/drm/litevideo/litevideo.c
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2020 Antmicro <www.antmicro.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <drm/drm_device.h>
+#include <drm/drm_drv.h>
+#include <drm/drm_ioctl.h>
+#include <drm/drm_prime.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/wait.h>
+#include <linux/platform_device.h>
+#include <linux/types.h>
+#include <linux/litex.h>
+#include <linux/errno.h>
+
+#include "litevideo.h"
+#include "mmcm.h"
+
+#define DRIVER_NAME     "litevideo"
+
+#define DMA_DISABLE     0
+#define DMA_ENABLE      1
+
+static void litevideo_get_md(u32 pixel_clock, u32 *best_m, u32 *best_d)
+{
+	u32 ideal_m, ideal_d, curr_m, curr_d, m, d;
+	u32 curr_diff, test_diff;
+
+	ideal_m = pixel_clock;
+	ideal_d = LITEVIDEO_IDEAL_DIV_VALUE;
+
+	/* Start searching from minimum values */
+
+	curr_m = MMCM_MIN_M;
+	curr_d = MMCM_MIN_D;
+
+	for (d = MMCM_MIN_D; d < MMCM_MAX_D; d++) {
+		for (m = MMCM_MIN_M; m < MMCM_MAX_M; m++) {
+
+			/* Clocks cannot be set perfectly, therefore all
+			 * combinations for multiplier (m) and divisor (d)
+			 * are checked to find the closest possible clock value
+			 */
+
+			curr_diff = abs((d * ideal_d * curr_m) -
+					(d * curr_d * ideal_m));
+			test_diff = abs((curr_d * ideal_d * m) -
+					(d * curr_d * ideal_m));
+
+			if (test_diff < curr_diff) {
+				curr_m = m;
+				curr_d = d;
+			}
+		}
+	}
+
+	*best_m = curr_m;
+	*best_d = curr_d;
+}
+
+static int litevideo_mmcm_write(struct litevideo_prv *prv, u32 addr, u32 data)
+{
+	/* write MMCM register address */
+
+	litex_write8(prv->base + LITEVIDEO_MMCM_ADDR_OFF, addr);
+
+	/* write data to send to MMCM register */
+
+	litex_write16(prv->base + LITEVIDEO_MMCM_DATA_OFF, data);
+
+	/* send the data */
+
+	litex_write8(prv->base + LITEVIDEO_MMCM_WRITE_OFF, MMCM_WRITE);
+
+	/* wait for transfer finish */
+
+	if (!wait_event_timeout(prv->wq,
+			litex_read8(prv->base + LITEVIDEO_MMCM_READY_OFF),
+			HZ))
+		return -ETIMEDOUT;
+
+	return 0;
+}
+
+static int litevideo_clkgen_write(struct litevideo_prv *prv, u32 m, u32 d)
+{
+	/* write M */
+
+	int ret;
+
+	ret = litevideo_mmcm_write(prv, MMCM_CLKFBOUT1,
+				   MMCM_HT_FALLING_EDGE |
+				   (m / 2) << MMCM_HT_SHIFT |
+				   (m / 2 + (m % 2)) << MMCM_LT_SHIFT);
+
+	if (ret < 0)
+		return ret;
+
+	/* write D */
+
+	if (d == 1)
+		ret = litevideo_mmcm_write(prv, MMCM_DIVCLK,
+					   MMCM_HT_FALLING_EDGE);
+	else
+		ret = litevideo_mmcm_write(prv, MMCM_DIVCLK,
+					   (d / 2) << MMCM_HT_SHIFT |
+					   (d / 2 + (d % 2)) << MMCM_LT_SHIFT);
+
+	if (ret < 0)
+		return ret;
+
+	/* clkout0_divide = 10 */
+
+	ret = litevideo_mmcm_write(prv, MMCM_CLKOUT0,
+				   MMCM_HT_FALLING_EDGE |
+				   MMCM_CLKOUT_DIV10 << MMCM_HT_SHIFT |
+				   MMCM_CLKOUT_DIV10 << MMCM_LT_SHIFT);
+
+	if (ret < 0)
+		return ret;
+
+	/* clkout1_divide = 2 */
+
+	ret = litevideo_mmcm_write(prv, MMCM_CLKOUT1,
+				   MMCM_HT_FALLING_EDGE |
+				   MMCM_CLKOUT_DIV2 << MMCM_HT_SHIFT |
+				   MMCM_CLKOUT_DIV2 << MMCM_LT_SHIFT);
+
+	return ret;
+}
+
+static int litevideo_drv_init(struct litevideo_prv *prv, u32 m, u32 d)
+{
+	int ret;
+
+	/* initialize waitqueue for timeouts in litex_mmcm_write() */
+
+	init_waitqueue_head(&prv->wq);
+
+	/* generate clock */
+
+	ret = litevideo_clkgen_write(prv, m, d);
+	if (ret < 0)
+		return ret;
+
+	/* timings - horizontal */
+
+	litex_write16(prv->base + LITEVIDEO_CORE_HRES_OFF,
+		      prv->h_active);
+	litex_write16(prv->base + LITEVIDEO_CORE_HSYNC_START_OFF,
+		      prv->h_active + prv->h_front_porch);
+	litex_write16(prv->base + LITEVIDEO_CORE_HSYNC_END_OFF,
+		      prv->h_active + prv->h_front_porch + prv->v_sync);
+	litex_write16(prv->base + LITEVIDEO_CORE_HSCAN_OFF,
+		      prv->h_active + prv->h_blanking);
+
+	/* timings - vertical */
+
+	litex_write16(prv->base + LITEVIDEO_CORE_VRES_OFF,
+		      prv->v_active);
+	litex_write16(prv->base + LITEVIDEO_CORE_VSYNC_START_OFF,
+		      prv->v_active + prv->v_front_porch);
+	litex_write16(prv->base + LITEVIDEO_CORE_VSYNC_END_OFF,
+		      prv->v_active + prv->v_front_porch + prv->v_sync);
+	litex_write16(prv->base + LITEVIDEO_CORE_VSCAN_OFF,
+		      prv->v_active + prv->v_blanking);
+
+	/* configure DMA */
+
+	litex_write8(prv->base + LITEVIDEO_DMA_ENABLE_OFF, DMA_DISABLE);
+	// FIXME: gateware and this call should be updated to 64-bit base addr!
+	litex_write32(prv->base + LITEVIDEO_DMA_BASE_ADDR_OFF, prv->dma_offset);
+	litex_write32(prv->base + LITEVIDEO_DMA_LENGTH_OFF, prv->dma_length);
+	litex_write8(prv->base + LITEVIDEO_DMA_ENABLE_OFF, DMA_ENABLE);
+
+	return 0;
+}
+
+static int litevideo_probe(struct platform_device *pdev)
+{
+	struct device_node *np = pdev->dev.of_node;
+	struct litevideo_prv *prv;
+	struct resource *res;
+	int ret;
+	u32 val;
+	u32 m, d;
+
+	/* no device tree */
+
+	if (!np)
+		return -ENODEV;
+
+	prv = devm_kzalloc(&pdev->dev, sizeof(*prv), GFP_KERNEL);
+	if (!prv)
+		return -ENOMEM;
+
+	/* pixel clock */
+
+	ret = of_property_read_u32(np, "litevideo,pixel-clock", &val);
+	if (ret)
+		return -EINVAL;
+	prv->pixel_clock = val;
+
+	/* timings - vertical */
+
+	ret = of_property_read_u32(np, "litevideo,v-active", &val);
+	if (ret)
+		return -EINVAL;
+	prv->v_active = val;
+
+	ret = of_property_read_u32(np, "litevideo,v-blanking", &val);
+	if (ret)
+		return -EINVAL;
+	prv->v_blanking = val;
+
+	ret = of_property_read_u32(np, "litevideo,v-front-porch", &val);
+	if (ret)
+		return -EINVAL;
+	prv->v_front_porch = val;
+
+	ret = of_property_read_u32(np, "litevideo,v-sync", &val);
+	if (ret)
+		return -EINVAL;
+	prv->v_sync = val;
+
+	/* timings - horizontal */
+
+	ret = of_property_read_u32(np, "litevideo,h-active", &val);
+	if (ret)
+		return -EINVAL;
+	prv->h_active = val;
+
+	ret = of_property_read_u32(np, "litevideo,h-blanking", &val);
+	if (ret)
+		return -EINVAL;
+	prv->h_blanking = val;
+
+	ret = of_property_read_u32(np, "litevideo,h-front-porch", &val);
+	if (ret)
+		return -EINVAL;
+	prv->h_front_porch = val;
+
+	ret = of_property_read_u32(np, "litevideo,h-sync", &val);
+	if (ret)
+		return -EINVAL;
+	prv->h_sync = val;
+
+	/* DMA */
+
+	ret = of_property_read_u32(np, "litevideo,dma-offset", &val);
+	if (ret)
+		return -EINVAL;
+	prv->dma_offset = val;
+
+	ret = of_property_read_u32(np, "litevideo,dma-length", &val);
+	if (ret)
+		return -EINVAL;
+	prv->dma_length = val;
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	prv->base = devm_ioremap_resource(&pdev->dev, res);
+	if (!prv->base)
+		return -ENXIO;
+
+	litevideo_get_md(prv->pixel_clock, &m, &d);
+	return litevideo_drv_init(prv, m, d);
+}
+
+static const struct of_device_id litevideo_of_match[] = {
+	{ .compatible = "litex,litevideo" },
+	{}
+};
+MODULE_DEVICE_TABLE(of, litevideo_of_match);
+
+static struct platform_driver litevideo_platform_driver = {
+	.probe = litevideo_probe,
+	.driver = {
+		.name = DRIVER_NAME,
+		.owner = THIS_MODULE,
+		.of_match_table = litevideo_of_match,
+	},
+};
+
+module_platform_driver(litevideo_platform_driver);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("LiteVideo driver");
+MODULE_AUTHOR("Antmicro <www.antmicro.com>");
+MODULE_ALIAS("platform:" DRIVER_NAME);

--- a/drivers/gpu/drm/litevideo/litevideo.h
+++ b/drivers/gpu/drm/litevideo/litevideo.h
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: GPL-2.0
+ *
+ * Copyright (C) 2020 Antmicro <www.antmicro.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _LITEVIDEO_LITEVIDEO_H_
+#define _LITEVIDEO_LITEVIDEO_H_
+
+#include <drm/drm.h>
+#include <linux/of.h>
+#include <linux/clk.h>
+#include <linux/wait.h>
+
+/* register offsets */
+
+#define LITEVIDEO_CORE_HRES_OFF          0x1c
+#define LITEVIDEO_CORE_HSYNC_START_OFF   0x24
+#define LITEVIDEO_CORE_HSYNC_END_OFF     0x2c
+#define LITEVIDEO_CORE_HSCAN_OFF         0x34
+#define LITEVIDEO_CORE_VRES_OFF          0x3c
+#define LITEVIDEO_CORE_VSYNC_START_OFF   0x44
+#define LITEVIDEO_CORE_VSYNC_END_OFF     0x4c
+#define LITEVIDEO_CORE_VSCAN_OFF         0x54
+
+#define LITEVIDEO_MMCM_WRITE_OFF         0x94
+#define LITEVIDEO_MMCM_READY_OFF         0x98
+#define LITEVIDEO_MMCM_ADDR_OFF          0x9c
+#define LITEVIDEO_MMCM_DATA_OFF          0xa0
+
+#define LITEVIDEO_DMA_ENABLE_OFF         0x18
+#define LITEVIDEO_DMA_BASE_ADDR_OFF      0x5c
+#define LITEVIDEO_DMA_LENGTH_OFF         0x6c
+
+/* register sizes */
+
+#define LITEVIDEO_CORE_HRES_SIZE         2
+#define LITEVIDEO_CORE_HSYNC_START_SIZE  2
+#define LITEVIDEO_CORE_HSYNC_END_SIZE    2
+#define LITEVIDEO_CORE_HSCAN_SIZE        2
+#define LITEVIDEO_CORE_VRES_SIZE         2
+#define LITEVIDEO_CORE_VSYNC_START_SIZE  2
+#define LITEVIDEO_CORE_VSYNC_END_SIZE    2
+#define LITEVIDEO_CORE_VSCAN_SIZE        2
+
+#define LITEVIDEO_MMCM_WRITE_SIZE        1
+#define LITEVIDEO_MMCM_READY_SIZE        1
+#define LITEVIDEO_MMCM_ADDR_SIZE         1
+#define LITEVIDEO_MMCM_DATA_SIZE         2
+
+#define LITEVIDEO_DMA_ENABLE_SIZE        1
+#define LITEVIDEO_DMA_BASE_ADDR_SIZE     4
+#define LITEVIDEO_DMA_LENGTH_SIZE        4
+
+/* constants */
+
+/* clk100 has to be used for LiteX VideoOut */
+#define LITEVIDEO_IDEAL_DIV_VALUE 10000
+
+struct litevideo_prv {
+	struct drm_device *drm_dev;
+	void __iomem *base;
+	struct clk *hdmi_clk;
+	wait_queue_head_t wq;
+	u32 h_active;
+	u32 h_blanking;
+	u32 h_front_porch;
+	u32 h_sync;
+	u32 v_active;
+	u32 v_blanking;
+	u32 v_front_porch;
+	u32 v_sync;
+	u32 dma_offset;
+	u32 dma_length;
+	u32 pixel_clock;
+};
+
+#endif /* _LITEVIDEO_LITEVIDEO_H_ */

--- a/drivers/gpu/drm/litevideo/mmcm.h
+++ b/drivers/gpu/drm/litevideo/mmcm.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: GPL-2.0
+ *
+ * Copyright (C) 2020 Antmicro <www.antmicro.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _LITEVIDEO_MMCM_H_
+#define _LITEVIDEO_MMCM_H_
+
+/* mmcm addresses */
+
+#define MMCM_CLKFBOUT1     0x14
+#define MMCM_DIVCLK        0x16
+#define MMCM_CLKOUT0       0x08
+#define MMCM_CLKOUT1       0x0a
+
+/* predefined values and shifts */
+
+#define MMCM_HT_FALLING_EDGE   0x1000
+#define MMCM_HT_SHIFT          6
+#define MMCM_LT_SHIFT          0
+
+/* This values should be set both to HIGH_TIME and LOW_TIME in CLKOUTx
+ * - clk division time = 2*VALUE   // (i.e. MMCM_CLKOUT_DIV10)
+ * - duty              = 50%       // (HIGH_TIME / (HIGH_TIME + LOW_TIME))
+ */
+
+#define MMCM_CLKOUT_DIV10  5
+#define MMCM_CLKOUT_DIV2   1
+
+#define MMCM_WRITE         1
+
+#define MMCM_MIN_M         2
+#define MMCM_MAX_M         128
+#define MMCM_MIN_D         1
+#define MMCM_MAX_D         128
+
+#endif /* _LITEVIDEO_MMCM_H_ */

--- a/drivers/irqchip/Kconfig
+++ b/drivers/irqchip/Kconfig
@@ -554,6 +554,27 @@ config LOONGSON_HTPIC
 	help
 	  Support for the Loongson-3 HyperTransport PIC Controller.
 
+config LITEX_VEXRISCV_INTC
+	bool "LiteX VexRiscv interrupt controller support"
+	depends on RISCV
+	depends on LITEX || COMPILE_TEST
+	select IRQ_DOMAIN
+	help
+	  Support for the VexRiscv's interrupt controller. VexRiscv does not follow
+	  RISC-V privileged specification and uses two additional CSRs: mask and
+	  pending. Please refer to LITEX_VEXRISCV_CSR_MASK and
+	  LITEX_VEXRISCV_CSR_PENDING for their respective configuration.
+
+config LITEX_VEXRISCV_CSR_MASK
+	depends on LITEX_VEXRISCV_INTC
+	hex "VexRiscv's mask CSR index."
+	default 0x9c0
+
+config LITEX_VEXRISCV_CSR_PENDING
+	depends on LITEX_VEXRISCV_INTC
+	hex "VexRiscv's pending CSR index."
+	default 0xdc0
+
 config LOONGSON_HTVEC
 	bool "Loongson3 HyperTransport Interrupt Vector Controller"
 	depends on MACH_LOONGSON64

--- a/drivers/irqchip/Makefile
+++ b/drivers/irqchip/Makefile
@@ -101,6 +101,7 @@ obj-$(CONFIG_SIFIVE_PLIC)		+= irq-sifive-plic.o
 obj-$(CONFIG_IMX_IRQSTEER)		+= irq-imx-irqsteer.o
 obj-$(CONFIG_IMX_INTMUX)		+= irq-imx-intmux.o
 obj-$(CONFIG_MADERA_IRQ)		+= irq-madera.o
+obj-$(CONFIG_LITEX_VEXRISCV_INTC)	+= irq-litex-vexriscv.o
 obj-$(CONFIG_LS1X_IRQ)			+= irq-ls1x.o
 obj-$(CONFIG_TI_SCI_INTR_IRQCHIP)	+= irq-ti-sci-intr.o
 obj-$(CONFIG_TI_SCI_INTA_IRQCHIP)	+= irq-ti-sci-inta.o

--- a/drivers/irqchip/irq-litex-vexriscv.c
+++ b/drivers/irqchip/irq-litex-vexriscv.c
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * VexRiscv interrupt controller driver
+ *
+ * Copyright (C) 2019 Antmicro Ltd. <www.antmicro.com>
+ */
+
+#include <linux/irq.h>
+#include <linux/irqchip.h>
+#include <linux/irqdesc.h>
+#include <linux/of.h>
+#include <linux/of_irq.h>
+#include <linux/of_address.h>
+
+#define IRQ_MASK	CONFIG_LITEX_VEXRISCV_CSR_MASK
+#define IRQ_PENDING	CONFIG_LITEX_VEXRISCV_CSR_PENDING
+#define IRQ_VEC_SZ	32
+
+static struct irq_domain *root_domain;
+
+struct litex_vexriscv_intc {
+	struct irq_chip chip;
+	irq_flow_handler_t handle;
+	unsigned long flags;
+};
+
+static unsigned int litex_vexriscv_irq_getie(void)
+{
+	return (csr_read(sstatus) & IE_SIE) != 0;
+}
+
+static void litex_vexriscv_irq_setie(unsigned int ie)
+{
+	if (ie)
+		csr_write(sstatus, IE_SIE);
+	else
+		csr_clear(sstatus, IE_SIE);
+}
+
+static unsigned int litex_vexriscv_irq_getmask(void)
+{
+	u32 mask;
+
+	__asm__ __volatile__ ("csrr %0, %1" : "=r"(mask) : "i"(IRQ_MASK));
+	return mask;
+}
+
+static void litex_vexriscv_irq_setmask(unsigned int mask)
+{
+	__asm__ volatile ("csrw %0, %1" :: "i"(IRQ_MASK), "r"(mask));
+}
+
+static unsigned int litex_vexriscv_irq_pending(void)
+{
+	u32 pending;
+
+	__asm__ __volatile__ ("csrr %0, %1" : "=r"(pending) : "i"(IRQ_PENDING));
+	return pending;
+}
+
+static int litex_vexriscv_intc_map(struct irq_domain *d, unsigned int irq,
+				   irq_hw_number_t hw)
+{
+	struct litex_vexriscv_intc *intc = d->host_data;
+
+	pr_debug("irqchip: LiteX Vexriscv irqmap: %d\n", irq);
+	irq_set_chip_and_handler(irq, &intc->chip, intc->handle);
+	irq_set_status_flags(irq, intc->flags);
+
+	pr_debug("irqchip: mapcount: %d\n", d->mapcount);
+
+	return 0;
+}
+
+static void litex_vexriscv_intc_mask(struct irq_data *data)
+{
+	unsigned int mask = litex_vexriscv_irq_getmask();
+	unsigned int irqbit = BIT(data->hwirq);
+
+	pr_debug("irqchip: LiteX VexRiscv irqchip mask: 0x%08x -> 0x%08x",
+		mask, mask & ~irqbit);
+	mask &= ~irqbit;
+	litex_vexriscv_irq_setmask(mask);
+
+	if (!mask)
+		litex_vexriscv_irq_setie(0);
+}
+
+static void litex_vexriscv_intc_unmask(struct irq_data *data)
+{
+	unsigned int mask = litex_vexriscv_irq_getmask();
+	unsigned int irqbit = BIT(data->hwirq);
+
+	pr_debug("irqchip: LiteX VexRiscv irqchip mask: 0x%08x -> 0x%08x",
+		mask, mask | irqbit);
+	mask |= irqbit;
+	litex_vexriscv_irq_setmask(mask);
+
+	if (!litex_vexriscv_irq_getie())
+		litex_vexriscv_irq_setie(1);
+}
+
+static void litex_vexriscv_intc_ack(struct irq_data *data)
+{
+	/* no need to ack IRQs */
+}
+
+static void litex_vexriscv_intc_handle_irq(struct pt_regs *regs)
+{
+	unsigned int irq;
+	int i;
+
+	irq = litex_vexriscv_irq_pending() & litex_vexriscv_irq_getmask();
+	pr_debug("irqchip: Litex Vexriscv irqchip mask: 0x%08x pending: 0x%08x",
+		litex_vexriscv_irq_getmask(),
+		litex_vexriscv_irq_pending());
+
+	for (i = 0; i < IRQ_VEC_SZ; i++) {
+		pr_debug("irqchip: i %d, irq 0x%08x, trying 0x%08lx\n", i, irq, BIT(i));
+
+		if (irq & BIT(i)) {
+			pr_debug("irqchip: handling at i = %d\n", i);
+			generic_handle_domain_irq(root_domain, i);
+		}
+	}
+}
+
+static const struct irq_domain_ops litex_vexriscv_domain_ops = {
+	.xlate	= irq_domain_xlate_onecell,
+	.map	= litex_vexriscv_intc_map,
+};
+
+static struct litex_vexriscv_intc litex_vexriscv_intc0 = {
+	.handle	= handle_edge_irq,
+	.flags	= IRQ_TYPE_DEFAULT | IRQ_TYPE_PROBE,
+	.chip	= {
+		.name		= "litex-vexriscv-intc0",
+		.irq_mask	= litex_vexriscv_intc_mask,
+		.irq_unmask	= litex_vexriscv_intc_unmask,
+		.irq_ack	= litex_vexriscv_intc_ack,
+	},
+};
+
+static int __init litex_vexriscv_intc_init(struct device_node *node, struct device_node *parent)
+{
+	/* clear interrupts for init */
+	litex_vexriscv_irq_setie(0);
+	litex_vexriscv_irq_setmask(0);
+
+	root_domain = irq_domain_add_linear(node, IRQ_VEC_SZ,
+					    &litex_vexriscv_domain_ops,
+					    &litex_vexriscv_intc0);
+	irq_set_default_host(root_domain);
+	set_handle_irq(litex_vexriscv_intc_handle_irq);
+
+	/* print device info */
+	pr_info("irqchip: LiteX VexRiscv irqchip driver initialized. "
+		"IE: %d, mask: 0x%08x, pending: 0x%08x\n",
+		litex_vexriscv_irq_getie(),
+		litex_vexriscv_irq_getmask(),
+		litex_vexriscv_irq_pending());
+	pr_info("irqchip: LiteX VexRiscv irqchip settings: "
+		"mask CSR 0x%03x, pending CSR 0x%03x\n", IRQ_MASK,
+		IRQ_PENDING);
+
+	return 0;
+}
+
+IRQCHIP_DECLARE(litex_vexriscv_intc0, "vexriscv,intc0", litex_vexriscv_intc_init);


### PR DESCRIPTION
As of commit 4ba0b2c294fe6919 ("fpga: mgr: Use standard dev_release for
class driver"):

    drivers/fpga/litex-fpga.c: In function ‘litex_fpga_probe’:
    drivers/fpga/litex-fpga.c:168:8: error: implicit declaration of function ‘devm_fpga_mgr_create’; did you mean ‘devm_fpga_mgr_register’? [-Werror=implicit-function-declaration]
      168 |  mgr = devm_fpga_mgr_create(&pdev->dev,
	  |        ^~~~~~~~~~~~~~~~~~~~
	  |        devm_fpga_mgr_register
    drivers/fpga/litex-fpga.c:168:6: warning: assignment to ‘struct fpga_manager *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
      168 |  mgr = devm_fpga_mgr_create(&pdev->dev,
	  |      ^
    drivers/fpga/litex-fpga.c:175:27: error: passing argument 1 of ‘fpga_mgr_register’ from incompatible pointer type [-Werror=incompatible-pointer-types]
      175 |  return fpga_mgr_register(mgr);
	  |                           ^~~
	  |                           |
	  |                           struct fpga_manager *
    In file included from drivers/fpga/litex-fpga.c:21:
    include/linux/fpga/fpga-mgr.h:217:1: note: expected ‘struct device *’ but argument is of type ‘struct fpga_manager *’
      217 | fpga_mgr_register(struct device *parent, const char *name,
	  | ^~~~~~~~~~~~~~~~~
    drivers/fpga/litex-fpga.c:175:9: error: too few arguments to function ‘fpga_mgr_register’
      175 |  return fpga_mgr_register(mgr);
	  |         ^~~~~~~~~~~~~~~~~
    In file included from drivers/fpga/litex-fpga.c:21:
    include/linux/fpga/fpga-mgr.h:217:1: note: declared here
      217 | fpga_mgr_register(struct device *parent, const char *name,
	  | ^~~~~~~~~~~~~~~~~
    drivers/fpga/litex-fpga.c:176:1: error: control reaches end of non-void function [-Werror=return-type]
      176 | }
	  | ^

Update the LiteX ICAPBitstream FPGA Manager driver accordingly.

Fixes: 0b11c29cec385479 ("LiteX: driver for ICAPBitstream fpga manager")
Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>
---
Compile-tested only.
Feel free to fold into the original commit.