### PR TITLE
RFC: LiteSDCard: Add support for DMA/data completion interrupts

### DIFF
--- a/drivers/mmc/host/litex_mmc.c
+++ b/drivers/mmc/host/litex_mmc.c
@@ -498,6 +498,8 @@ static int litex_mmc_irq_init(struct platform_device *pdev,
 	litex_write32(host->sdirq + LITEX_IRQ_PENDING, SDIRQ_CARD_DETECT);
 	litex_write32(host->sdirq + LITEX_IRQ_ENABLE, SDIRQ_CARD_DETECT);
 
+	init_completion(&host->cmd_done);
+
 	return 0;
 
 use_polling:
@@ -583,7 +585,6 @@ static int litex_mmc_probe(struct platform_device *pdev)
 	litex_write8(host->sdreader + LITEX_BLK2MEM_ENA, 0);
 	litex_write8(host->sdwriter + LITEX_MEM2BLK_ENA, 0);
 
-	init_completion(&host->cmd_done);
 	ret = litex_mmc_irq_init(pdev, host);
 	if (ret)
 		return ret;

--- a/drivers/mmc/host/litex_mmc.c
+++ b/drivers/mmc/host/litex_mmc.c
@@ -68,10 +68,10 @@
 #define SD_SLEEP_US       5
 #define SD_TIMEOUT_US 20000
 
-#define SDIRQ_CARD_DETECT    1
-#define SDIRQ_SD_TO_MEM_DONE 2
-#define SDIRQ_MEM_TO_SD_DONE 4
-#define SDIRQ_CMD_DONE       8
+#define SDIRQ_CARD_DETECT    BIT(0)
+#define SDIRQ_SD_TO_MEM_DONE BIT(1)
+#define SDIRQ_MEM_TO_SD_DONE BIT(2)
+#define SDIRQ_CMD_DONE       BIT(3)
 
 struct litex_mmc_host {
 	struct mmc_host *mmc;

--- a/drivers/mmc/host/litex_mmc.c
+++ b/drivers/mmc/host/litex_mmc.c
@@ -124,6 +124,9 @@ static int litex_mmc_send_cmd(struct litex_mmc_host *host,
 			      u8 cmd, u32 arg, u8 response_len, u8 transfer)
 {
 	struct device *dev = mmc_dev(host->mmc);
+	bool use_irq = host->irq > 0 &&
+			(transfer != SD_CTL_DATA_XFER_NONE ||
+			 response_len == SD_CTL_RESP_SHORT_BUSY);
 	int ret;
 
 	litex_write32(host->sdcore + LITEX_CORE_CMDARG, arg);
@@ -135,9 +138,7 @@ static int litex_mmc_send_cmd(struct litex_mmc_host *host,
 	 * Wait for an interrupt if we have an interrupt and either there is
 	 * data to be transferred, or if the card can report busy via DAT0.
 	 */
-	if (host->irq > 0 &&
-	    (transfer != SD_CTL_DATA_XFER_NONE ||
-	     response_len == SD_CTL_RESP_SHORT_BUSY)) {
+	if (use_irq) {
 		reinit_completion(&host->cmd_done);
 		litex_write32(host->sdirq + LITEX_IRQ_ENABLE,
 			      SDIRQ_CMD_DONE | SDIRQ_CARD_DETECT);

--- a/drivers/mmc/host/litex_mmc.c
+++ b/drivers/mmc/host/litex_mmc.c
@@ -129,19 +129,19 @@ static int litex_mmc_send_cmd(struct litex_mmc_host *host,
 			 response_len == SD_CTL_RESP_SHORT_BUSY);
 	int ret;
 
+	if (use_irq) {
+		reinit_completion(&host->cmd_done);
+		litex_write32(host->sdirq + LITEX_IRQ_ENABLE,
+			      SDIRQ_CMD_DONE | SDIRQ_CARD_DETECT);
+	}
+
+	/* Send command */
 	litex_write32(host->sdcore + LITEX_CORE_CMDARG, arg);
 	litex_write32(host->sdcore + LITEX_CORE_CMDCMD,
 		      cmd << 8 | transfer << 5 | response_len);
 	litex_write8(host->sdcore + LITEX_CORE_CMDSND, 1);
 
-	/*
-	 * Wait for an interrupt if we have an interrupt and either there is
-	 * data to be transferred, or if the card can report busy via DAT0.
-	 */
 	if (use_irq) {
-		reinit_completion(&host->cmd_done);
-		litex_write32(host->sdirq + LITEX_IRQ_ENABLE,
-			      SDIRQ_CMD_DONE | SDIRQ_CARD_DETECT);
 		wait_for_completion(&host->cmd_done);
 	}
 

--- a/drivers/mmc/host/litex_mmc.c
+++ b/drivers/mmc/host/litex_mmc.c
@@ -124,14 +124,10 @@ static int litex_mmc_send_cmd(struct litex_mmc_host *host,
 			      u8 cmd, u32 arg, u8 response_len, u8 transfer)
 {
 	struct device *dev = mmc_dev(host->mmc);
-	bool use_irq = host->irq > 0 &&
-			(transfer != SD_CTL_DATA_XFER_NONE ||
-			 response_len == SD_CTL_RESP_SHORT_BUSY);
 	int ret;
 
-	if (use_irq) {
+	if (host->irq > 0)
 		reinit_completion(&host->cmd_done);
-	}
 
 	/* Send command */
 	litex_write32(host->sdcore + LITEX_CORE_CMDARG, arg);
@@ -139,9 +135,8 @@ static int litex_mmc_send_cmd(struct litex_mmc_host *host,
 		      cmd << 8 | transfer << 5 | response_len);
 	litex_write8(host->sdcore + LITEX_CORE_CMDSND, 1);
 
-	if (use_irq) {
+	if (host->irq > 0)
 		wait_for_completion(&host->cmd_done);
-	}
 
 	ret = litex_mmc_sdcard_wait_done(host->sdcore + LITEX_CORE_CMDEVT, dev);
 	if (ret) {

--- a/drivers/mmc/host/litex_mmc.c
+++ b/drivers/mmc/host/litex_mmc.c
@@ -124,9 +124,7 @@ static int litex_mmc_send_cmd(struct litex_mmc_host *host,
 			      u8 cmd, u32 arg, u8 response_len, u8 transfer)
 {
 	struct device *dev = mmc_dev(host->mmc);
-	void __iomem *reg;
 	int ret;
-	u8 evt;
 
 	litex_write32(host->sdcore + LITEX_CORE_CMDARG, arg);
 	litex_write32(host->sdcore + LITEX_CORE_CMDCMD,
@@ -169,20 +167,14 @@ static int litex_mmc_send_cmd(struct litex_mmc_host *host,
 	if (transfer == SD_CTL_DATA_XFER_NONE)
 		return ret; /* OK from prior litex_mmc_sdcard_wait_done() */
 
+	/*
+	 * NOTE: this information becomes available at the same time
+	 * as LITEX_CORE_CMDEVT, and is therefore also covered by the
+	 * SDIRQ_CMD_DONE interrupt and cmd_done completion
+	 */
 	ret = litex_mmc_sdcard_wait_done(host->sdcore + LITEX_CORE_DATEVT, dev);
-	if (ret) {
-		dev_err(dev, "Data xfer (cmd %d) error, status %d\n", cmd, ret);
-		return ret;
-	}
-
-	/* Wait for completion of (read or write) DMA transfer */
-	reg = (transfer == SD_CTL_DATA_XFER_READ) ?
-		host->sdreader + LITEX_BLK2MEM_DONE :
-		host->sdwriter + LITEX_MEM2BLK_DONE;
-	ret = readx_poll_timeout(litex_read8, reg, evt, evt & SD_BIT_DONE,
-				 SD_SLEEP_US, SD_TIMEOUT_US);
 	if (ret)
-		dev_err(dev, "DMA timeout (cmd %d)\n", cmd);
+		dev_err(dev, "Data xfer (cmd %d) error, status %d\n", cmd, ret);
 
 	return ret;
 }
@@ -389,6 +381,20 @@ static void litex_mmc_request(struct mmc_host *mmc, struct mmc_request *mrq)
 		cmd->error = litex_mmc_send_cmd(host, cmd->opcode, cmd->arg,
 						response_len, transfer);
 	} while (cmd->error && retries-- > 0);
+
+	if (!cmd->error && transfer != SD_CTL_DATA_XFER_NONE) {
+		void __iomem *reg = (transfer == SD_CTL_DATA_XFER_READ) ?
+					host->sdreader + LITEX_BLK2MEM_DONE :
+					host->sdwriter + LITEX_MEM2BLK_DONE;
+		u8 evt;
+
+		/* Wait for completion of (read or write) DMA transfer */
+		cmd->error = readx_poll_timeout(litex_read8, reg,
+						evt, evt & SD_BIT_DONE,
+						SD_SLEEP_US, SD_TIMEOUT_US);
+		if (cmd->error)
+			dev_err(dev, "DMA timeout (cmd %d)\n", cmd->opcode);
+	}
 
 	if (cmd->error) {
 		/* Card may be gone; don't assume bus width is still set */


### PR DESCRIPTION
This is the new/reworked version of https://github.com/litex-hub/linux/pull/15, which should offer a cleaner sequence of steps getting from the current state to the desired end goal of including dma completion support.

Depends on https://github.com/enjoy-digital/litex/pull/1787 being applied.

The important patches are [5/10 ("fix cmd irq/completion sequencing")](https://github.com/litex-hub/linux/commit/5a7c0537ce557bb2673b6e85164b5e90ffa42846) and [6/10 ("switch cmd_done irq to edge-triggered")](https://github.com/litex-hub/linux/commit/f1557fa2e5630835447392ecc177cc26bbf8c2aa); the latter requires https://github.com/enjoy-digital/litex/pull/1787 to be applied (breaking compatibility with the way LiteSDCard/Litex gateware operated before that point).